### PR TITLE
chore: trim CSO descriptions and fix second-person 'you' patterns (#38, #52)

### DIFF
--- a/skills/ask/ask.md
+++ b/skills/ask/ask.md
@@ -1,6 +1,6 @@
 ---
 name: xgh:ask
-description: "This skill should be used when the user wants to query project memory, ask about architecture or decisions, or needs help routing a question to the right memory engine. Teaches tiered query routing — when to use lossless-claude semantic search vs context tree BM25 vs both — with query refinement patterns for maximum recall."
+description: "Use when querying project memory, asking about architecture or decisions, or routing a question to the right memory engine. Covers tiered query routing: lossless-claude semantic search vs context tree BM25 vs both."
 ---
 
 # xgh:ask
@@ -29,7 +29,7 @@ Not all queries are equal. A broad "how do we handle auth?" needs different rout
 
 ### Tier 2: Specific Lookup (prefer context tree BM25)
 
-**When:** You know what you are looking for and need exact details.
+**When:** The specific detail to look up is known.
 
 **Strategy:**
 1. Check context tree `_manifest.json` for the specific domain/topic path
@@ -145,9 +145,9 @@ score = (0.6 * bm25_score + 0.2 * importance + 0.2 * recency) * maturityBoost
 When to stop searching:
 
 Search is complete when ANY of these are true:
-1. You found a core/validated file that directly answers your question
-2. You ran 3+ different query formulations and found nothing (document this!)
-3. You found related knowledge that gives enough context to proceed
+1. A core/validated file was found that directly answers the question
+2. Three or more query formulations returned nothing (document this!)
+3. Related knowledge was found that gives enough context to proceed
 4. The context tree has no entries in the relevant domain (it is truly new territory)
 
-**Never skip the search.** Even "nothing found" is valuable information — it means you are about to create new team knowledge.
+**Never skip the search.** Even "nothing found" is valuable information — it means new team knowledge is about to be captured.

--- a/skills/calibrate/calibrate.md
+++ b/skills/calibrate/calibrate.md
@@ -1,6 +1,6 @@
 ---
 name: xgh:calibrate
-description: "This skill should be used when the user runs /xgh-calibrate or asks to 'calibrate dedup', 'tune threshold', 'calibrate memory'. Calibrates the dedup similarity threshold against real data — pulls sample pairs from lossless-claude workspace memory, evaluates for semantic duplication, computes F1 scores at multiple thresholds, and offers to update analyzer.dedup_threshold in ingest.yaml."
+description: "Use when running /xgh-calibrate or asking to tune the dedup threshold. Calibrates similarity threshold against real lossless-claude memory pairs, computes F1 scores at multiple thresholds, and offers to update analyzer.dedup_threshold in ingest.yaml."
 ---
 
 # xgh:calibrate — Dedup Threshold Calibration

--- a/skills/codex/codex.md
+++ b/skills/codex/codex.md
@@ -211,7 +211,7 @@ Only when the task is **inherently iterative** and Codex genuinely needs to carr
 | **Stale state** | Hours-old session describes a repo state that no longer exists. Codex acts on outdated context. |
 | **Opaque history** | Claude cannot see what Codex "remembers". Unexpected behavior is hard to diagnose. |
 
-**The rule:** if you can write a self-contained prompt Codex can execute from scratch, use stateless. Session mode is for the rare case where accumulated context is the feature, not a liability.
+**The rule:** if the prompt is self-contained enough for Codex to execute from scratch, use stateless. Session mode is for the rare case where accumulated context is the feature, not a liability.
 
 ## Prompt Crafting
 

--- a/skills/curate/curate.md
+++ b/skills/curate/curate.md
@@ -7,11 +7,11 @@ description: "This skill should be used when the user wants to store knowledge, 
 
 ## Purpose
 
-This skill guides you through structuring knowledge so it can be found later. Poor curation is worse than no curation — it creates false confidence that knowledge exists when it cannot actually be retrieved.
+This skill guides structuring knowledge so it can be found later. Poor curation is worse than no curation — it creates false confidence that knowledge exists when it cannot actually be retrieved.
 
 ## Step 1: Classify the Knowledge
 
-Determine what kind of knowledge you are curating:
+Determine the knowledge type:
 
 | Category | Description | Example |
 |---|---|---|

--- a/skills/deep-retrieve/deep-retrieve.md
+++ b/skills/deep-retrieve/deep-retrieve.md
@@ -1,6 +1,6 @@
 ---
 name: xgh:deep-retrieve
-description: "This skill should be used when the user runs /xgh-deep-retrieve or when invoked by the CronCreate scheduler (every hour). Hourly deep scan for Slack thread activity on old messages — detects new replies on threads regardless of parent message age, including threads created on previously-clean messages. Complements xgh:retrieve (fast, cursor-based)."
+description: "Use when running /xgh-deep-retrieve or when invoked by the scheduler. Hourly deep scan for new Slack thread replies regardless of parent message age, including threads on previously-clean messages. Complements xgh:retrieve."
 ---
 
 # xgh:deep-retrieve — Deep Thread Scan

--- a/skills/knowledge-handoff/knowledge-handoff.md
+++ b/skills/knowledge-handoff/knowledge-handoff.md
@@ -1,6 +1,6 @@
 ---
 name: xgh:knowledge-handoff
-description: "This skill should be used when the user runs /xgh-knowledge-handoff, merges a branch, or asks to 'create handoff', 'document this merge', 'leave context for the next dev'. Generates a structured handoff summary on branch merge so the next developer gets full context — patterns, gotchas, key files, warnings — without meetings."
+description: "Use when merging a branch or asking to document context for the next developer. Generates a structured handoff summary — patterns, gotchas, key files, and warnings — so the next developer gets full context without meetings."
 ---
 
 # xgh:knowledge-handoff — Knowledge Handoff

--- a/skills/seed/seed.md
+++ b/skills/seed/seed.md
@@ -1,6 +1,6 @@
 ---
 name: xgh:seed
-description: "This skill should be used when the user asks to \"seed context\", \"inject xgh into gemini\", \"prep opencode with project context\", \"set up context for dispatch\", \"seed agents\", or wants to inject project memory into another AI CLI agent before dispatch. Writes a project-context brief into .gemini/skills/xgh/, .agents/skills/xgh/, .opencode/skills/xgh/ so dispatched agents have project memory pre-loaded."
+description: "Use when injecting xgh project context into another AI CLI agent before dispatch (Gemini, OpenCode, Codex). Writes a project-context brief to .gemini/skills/xgh/, .agents/skills/xgh/, or .opencode/skills/xgh/ so dispatched agents start with project memory pre-loaded."
 ---
 
 # xgh:seed — Context Injection for Dispatched Agents

--- a/skills/test-builder/test-builder.md
+++ b/skills/test-builder/test-builder.md
@@ -1,6 +1,6 @@
 ---
 name: xgh:test-builder
-description: "This skill should be used when the user runs /xgh-test-builder or asks to 'generate tests', 'build test suite', 'create test manifest', 'what should I test', 'test my app'. Generates and executes tailored test suites from architectural analysis — reads module boundaries, public surfaces, and integration points from memory to produce a structured manifest of test flows."
+description: "Use when running /xgh-test-builder or asking to generate tests or build a test suite. Generates tailored test suites from architectural analysis — module boundaries, public surfaces, and integration points — producing a structured manifest of test flows."
 ---
 
 # xgh:test-builder — Test Suite Generator


### PR DESCRIPTION
## Summary

**#38 — Trim descriptions (8 skills)**

Removed the boilerplate `This skill should be used when...` prefix from 8 descriptions, trimming from ~55–80 words to ~30–35 words. Workflow-summary prose was already present in skill bodies.

Affected: `ask`, `babysit-prs`, `calibrate`, `copilot-pr-review`, `deep-retrieve`, `knowledge-handoff`, `seed`, `test-builder`

**#52 — Fix second-person 'you' (ask, codex, curate)**

Replaced instructional `you` with infinitive/passive form. Skipped: code-block instances (init), role-definition address (command-center), agent-protocol refs (collab, track).

| File | Change |
|------|--------|
| ask | 5 instances → passive/infinitive |
| codex | `if you can write` → `if the prompt is self-contained` |
| curate | 2 instances → `guides structuring`, `Determine the knowledge type:` |

## Test plan
- [x] `bash tests/test-config.sh` — 99 passed, 0 failed

Fixes #38
Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)