### PR TITLE
chore: sync version bump 2.1.1 to develop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xgh",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "author": {
     "name": "Pedro Almeida",
     "email": "pedro.almeida@users.noreply.github.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreme-go-horse/xgh",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
Syncs the v2.1.1 version bump in `package.json` and `.claude-plugin/plugin.json` from main back to develop.