### PR TITLE
Release 2.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xgh",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": {
     "name": "Pedro Almeida",
     "email": "pedro.almeida@users.noreply.github.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreme-go-horse/xgh",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

- Merges all `develop` changes into `main` for the v2.1.1 release
- Resolves version conflict: keeps `2.1.1` (develop) over `2.1.0` (main's earlier bump)

### Included since last release
- feat: split watch-prs → watch-prs (passive) + ship-prs (active orchestrator)
- feat: improve babysit-prs — CronCreate scheduling + github-pr-poller haiku agent
- chore: TDD verification pass for exemplar skills (#53-#59)
- chore: version bump 2.1.1

## Test plan

- [ ] Version is `2.1.1` in both `package.json` and `.claude-plugin/plugin.json`
- [ ] `publish.yml` will trigger on merge and publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)