### PR TITLE
fix: remove npm cache from publish.yml — no package-lock.json in repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-          cache: npm
 
       - name: Check if version already released
         id: check


### PR DESCRIPTION
## Summary

`cache: npm` in `actions/setup-node` requires a lock file (`package-lock.json` or `yarn.lock`). This repo has no Node dependencies so no lock file exists — removing the cache option unblocks the publish workflow.

## Test plan

- [ ] Publish workflow completes past the Setup Node step
- [ ] v2.1.1 publishes to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)