### PR TITLE
chore: fix publish.yml — remove npm cache, add version-sync check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-          cache: npm
 
       - name: Check if version already released
         id: check
@@ -49,6 +48,23 @@ jobs:
           else
             printf 'skip=false\n' >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Verify version files are in sync
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          version="${{ steps.check.outputs.version }}"
+          plugin_version="$(node -p "require('./.claude-plugin/plugin.json').version")"
+          marketplace_version="$(node -p "require('./.claude-plugin/marketplace.json').plugins[0].version")"
+          ok=true
+          if [ "$plugin_version" != "$version" ]; then
+            echo "ERROR: .claude-plugin/plugin.json version '$plugin_version' != package.json '$version'" >&2
+            ok=false
+          fi
+          if [ "$marketplace_version" != "$version" ]; then
+            echo "ERROR: .claude-plugin/marketplace.json version '$marketplace_version' != package.json '$version'" >&2
+            ok=false
+          fi
+          [ "$ok" = "true" ] || exit 1
 
       - name: Set up Python
         if: steps.check.outputs.skip == 'false'


### PR DESCRIPTION
## Summary

- **Remove `cache: npm`** — no `package-lock.json` in this repo, was causing CI failures
- **Add version-sync validation** — publish now fails early if `plugin.json` or `marketplace.json` version doesn't match `package.json`

```
ERROR: .claude-plugin/plugin.json version '2.1.0' != package.json '2.1.1'
ERROR: .claude-plugin/marketplace.json version '2.1.0' != package.json '2.1.1'
```

This enforces that all three version manifests stay in sync before any release goes out.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify version check step catches mismatches when tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)