### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "repo": "extreme-go-horse/xgh"
       },
       "description": "Declare your agent behavior in YAML. Converge every AI platform to match.",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xgh",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": {
     "name": "Pedro Almeida",
     "email": "pedro.almeida@users.noreply.github.com"
@@ -9,5 +9,11 @@
   "homepage": "https://github.com/extreme-go-horse/xgh",
   "repository": "https://github.com/extreme-go-horse/xgh",
   "license": "MIT",
-  "keywords": ["memory", "context", "workflow", "cockpit", "devtools"]
+  "keywords": [
+    "memory",
+    "context",
+    "workflow",
+    "cockpit",
+    "devtools"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreme-go-horse/xgh",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
Hotfix release to test the new publish workflow (version-sync check, no npm cache).

Bumps `package.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` to `2.1.2` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)