### PR TITLE
Release 2.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "repo": "extreme-go-horse/xgh"
       },
       "description": "Declare your agent behavior in YAML. Converge every AI platform to match.",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xgh",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": {
     "name": "Pedro Almeida",
     "email": "pedro.almeida@users.noreply.github.com"
@@ -9,5 +9,11 @@
   "homepage": "https://github.com/extreme-go-horse/xgh",
   "repository": "https://github.com/extreme-go-horse/xgh",
   "license": "MIT",
-  "keywords": ["memory", "context", "workflow", "cockpit", "devtools"]
+  "keywords": [
+    "memory",
+    "context",
+    "workflow",
+    "cockpit",
+    "devtools"
+  ]
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,23 @@ jobs:
             printf 'skip=false\n' >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify version files are in sync
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          version="${{ steps.check.outputs.version }}"
+          plugin_version="$(node -p "require('./.claude-plugin/plugin.json').version")"
+          marketplace_version="$(node -p "require('./.claude-plugin/marketplace.json').plugins[0].version")"
+          ok=true
+          if [ "$plugin_version" != "$version" ]; then
+            echo "ERROR: .claude-plugin/plugin.json version '$plugin_version' != package.json '$version'" >&2
+            ok=false
+          fi
+          if [ "$marketplace_version" != "$version" ]; then
+            echo "ERROR: .claude-plugin/marketplace.json version '$marketplace_version' != package.json '$version'" >&2
+            ok=false
+          fi
+          [ "$ok" = "true" ] || exit 1
+
       - name: Set up Python
         if: steps.check.outputs.skip == 'false'
         uses: actions/setup-python@v5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreme-go-horse/xgh",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

Hotfix release to validate the new publish pipeline end-to-end.

**What's new since 2.1.1:**
- `publish.yml`: version-sync check — fails if `plugin.json` or `marketplace.json` version doesn't match `package.json` before publishing
- `publish.yml`: remove `cache: npm` (no lock file in repo)
- `.claude-plugin/marketplace.json`: added for Claude Code marketplace

**On merge:** `publish.yml` triggers automatically (package.json changed on main), runs tests + version-sync check, publishes to npm, creates `v2.1.2` tag + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)