### PR TITLE
chore: flesh out content gaps across 6 skills (#46–#51)

### DIFF
--- a/skills/analyze/analyze.md
+++ b/skills/analyze/analyze.md
@@ -217,6 +217,25 @@ source ~/.xgh/lib/usage-tracker.sh
 xgh_usage_log "analyzer" "<actual turns>" 0
 ```
 
+## Common Mistakes
+
+### Misclassifying multi-type items
+Items that carry signals for multiple categories (e.g., both a spec and a design decision) often get classified as one or the other. When signals conflict, prefer the higher-specificity type: `decision` > `pattern` > `convention` > `discovery`. If genuinely ambiguous, use the type that matches the item's actionability.
+
+### Dedup false positives
+Two items with similar wording but different scopes (e.g., "auth token rotation" for iOS vs. web) may incorrectly match above the similarity threshold. If the same concept appears twice with divergent context tags or project assignments, keep both — tag divergence signals an intentional distinction.
+
+### Skipping TTL refresh on updated items
+If a source item's timestamp is newer than the memory's `created_at`, recalculate TTL from the new source date — not the original curation date. Forgetting this causes stale memories to survive past their correct expiry.
+
+### Creating duplicates instead of updating
+When an inbox item supersedes an existing memory, update the lossless-claude entry in place using `lcm_store` with the same title. Do not append a new entry — duplicates degrade retrieval quality and inflate dedup false-positive rates.
+
+### Filing items with no project match
+If an inbox item cannot be mapped to an active project in `ingest.yaml`, log `WARN: no project match for <item>` and skip it. Do not file it under a random or fallback project — misattributed memories are worse than no memory.
+
+---
+
 ## Output discipline
 
 1. Never dump raw inbox content into session context.

--- a/skills/calibrate/calibrate.md
+++ b/skills/calibrate/calibrate.md
@@ -65,3 +65,15 @@ Same as interactive, but use a Claude reasoning step to judge each pair ("Are th
 ## Comparison mode (--compare)
 
 Run headless calibration first, then run interactive on the same pairs. Show agreement rate between AI and human judgments at the end. This validates whether headless mode is reliable for future auto-runs.
+
+## Threshold Algorithm
+
+The dedup threshold is cosine similarity (0.0-1.0): pairs above threshold are considered duplicates. F1 score balances precision (avoid false duplicates) vs recall (catch true duplicates). Typical well-tuned threshold: 0.72-0.82 (project-dependent). Default (0.75) is a safe starting point; real data almost always improves it.
+
+## Error Handling
+
+Fewer than 10 sample pairs → print warning, abort calibration (not enough signal). F1 scores flat across all thresholds → already well-tuned, no change needed. Proposed threshold differs from current by >0.15 → confirm with user before writing to ingest.yaml. ingest.yaml unreadable → print path, suggest running /xgh-init to reinitialize.
+
+## Validation
+
+After updating analyzer.dedup_threshold in ingest.yaml, run /xgh-retrieve to fetch fresh items, then run /xgh-analyze and check the dedup report line: 'X duplicates suppressed'. If 0 duplicates suppressed on a project with history, threshold may be too low.

--- a/skills/collab/collab.md
+++ b/skills/collab/collab.md
@@ -135,16 +135,56 @@ The agent registry at `config/agents.yaml` lists all available agents and their 
 
 ## Workflow Templates
 
-Workflow definitions live in `config/workflows/*.yaml`. Each template defines:
-- **roles** — what each participant does
-- **steps** — ordered sequence with dependencies
-- **completion** — when the workflow is done
+Workflow definitions live in `config/workflows/*.yaml`. Each template defines the full coordination contract.
 
-Available workflows:
-- `plan-review` — 2 agents: plan → review → implement
-- `parallel-impl` — N agents: split → parallel implement → merge
-- `validation` — 2 agents: implement → validate → feedback loop
-- `security-review` — 2 agents: implement → security review → fix → re-review
+### Template Structure
+
+```yaml
+name: plan-review
+roles:
+  planner:
+    sends: [plan, decision]
+    receives: [review]
+  reviewer:
+    sends: [review]
+    receives: [plan]
+steps:
+  - id: draft-plan
+    role: planner
+    action: send
+    type: plan
+    next: review-plan
+  - id: review-plan
+    role: reviewer
+    action: send
+    type: review
+    next: finalize
+  - id: finalize
+    role: planner
+    action: send
+    type: decision
+completion:
+  condition: type == decision AND status == completed
+max_iterations: 3
+```
+
+### Available Workflows
+
+**plan-review** — Planner drafts, Reviewer critiques, Planner decides.
+Best for: architecture decisions, breaking down epics, risk assessment.
+
+**parallel-impl** — Coordinator splits work, N Implementers execute in parallel, Coordinator merges.
+Best for: implementing independent subtasks across multiple agents simultaneously.
+
+**validation** — Implementer builds, Validator tests and feeds back, repeat until approved.
+Best for: QA-gated features, security-sensitive changes.
+
+**security-review** — Implementer ships, Security Reviewer audits, Implementer fixes, repeat.
+Best for: auth changes, data exposure, any code touching secrets.
+
+### Parallel Execution Semantics
+
+In `parallel-impl`, the Coordinator sends one `type: plan` per implementer with unique `for_agent` values. All implementers work concurrently. The Coordinator polls with `lcm_search` until all expected `type: result` messages arrive before merging.
 
 ## Workflow Completion
 

--- a/skills/knowledge-handoff/knowledge-handoff.md
+++ b/skills/knowledge-handoff/knowledge-handoff.md
@@ -119,6 +119,35 @@ Identify which domain areas were touched by the merge. Use git diff to find:
 - Directories affected
 - Modules/domains impacted
 
+**Categorize files by type and risk:**
+
+| File pattern | Category | Risk level |
+|---|---|---|
+| `**/auth/**`, `**/security/**` | Security | High |
+| `**/api/**`, `**/routes/**` | API surface | High |
+| `**/migration/**`, `**/*.sql` | Data | High |
+| `**/config/**`, `*.yaml`, `*.json` | Config | Medium |
+| `src/**/*.ts`, `lib/**/*.py` | Core logic | Medium |
+| `**/*.test.*`, `**/*.spec.*` | Tests | Low |
+| `**/docs/**`, `*.md` | Docs | Low |
+
+**Assess impact breadth:**
+- 1-3 files changed: narrow, low coordination overhead
+- 4-10 files changed: moderate, check for cross-module coupling
+- 10+ files changed: broad refactor — explicitly call out in handoff summary
+
+**Identify coupling risks:**
+Run `git diff --name-only HEAD~1` and look for files in different modules that changed together — this often signals hidden coupling the next developer should know about.
+
+**Example output format:**
+```
+Affected: 7 files
+High risk: src/auth/token-refresh.ts (auth), migrations/004_add_session_index.sql (data)
+Medium risk: src/api/users.ts, config/rate-limits.yaml
+Low risk: tests/auth.test.ts, docs/auth.md
+Coupling signal: token-refresh.ts + rate-limits.yaml changed together — rate limit is tied to token lifetime
+```
+
 ### Step 3: Extract learnings from session
 
 ```

--- a/skills/retrieve/retrieve.md
+++ b/skills/retrieve/retrieve.md
@@ -305,6 +305,25 @@ source ~/.xgh/lib/usage-tracker.sh
 xgh_usage_log "retriever" "$(actual turns used)" 0
 ```
 
+## Error Handling
+
+### Provider timeouts
+If a bash provider (`fetch.sh`) runs longer than 60s, kill it and mark as timed-out. Log: `WARN: provider <name> timed out after 60s — skipping`. Continue with remaining providers; do not abort the full retrieval cycle.
+
+### Rate limiting (HTTP 429)
+Back off 30s and retry once. If the second attempt also returns 429, skip the provider and log a warning. Do not retry more than once per retrieval cycle.
+
+### Malformed provider output
+`fetch.sh` must output valid YAML frontmatter. If output fails YAML parse: log `ERROR: provider <name> returned invalid YAML — skipping item`. Continue processing remaining items from other providers.
+
+### Partial failure
+If 1 of N providers fails, continue and log a summary at the end: `Retrieved: X items (Y providers failed: <names>)`. Partial success is still success — do not abort or roll back the run.
+
+### Cursor corruption
+If `CURSOR_FILE` contains non-timestamp content, reset it to epoch (`1970-01-01T00:00:00Z`) and log: `WARN: cursor corrupted for <provider> — resetting to epoch`. This causes a full backfill on next run, which is preferable to skipping items silently.
+
+---
+
 ## Output discipline
 
 This skill runs in the main session turn (triggered by CronCreate or manually). To preserve context:

--- a/skills/todo-killer/todo-killer.md
+++ b/skills/todo-killer/todo-killer.md
@@ -89,7 +89,11 @@ TODO: migrate to async/await — callback hell
 Context: 30 lines around the comment
 ```
 
+Before fixing, also run `lcm_search('TODO context: <todo text>')` — check if this has been attempted before or if there's a known pattern for the migration.
+
 ### 2b. Classify fixability
+
+Use this decision tree:
 
 | Type | Action |
 |------|--------|
@@ -98,21 +102,45 @@ Context: 30 lines around the comment
 | Part of larger migration | Fix if `status: active` in patterns.yaml, skip if `planned` |
 | Already fixed (stale TODO) | Remove comment only |
 | Needs external context (ticket, PR) | Skip — note in output |
+| Blocked by another TODO in same cluster | Fix the blocker first |
+| Requires touching >3 unrelated files | Mark `complex` — flag for separate PR |
 
-### 2c. Fix
+### 2c. Fix — HOW to fix by TODO type
 
-- Make the change described by the TODO
-- Remove the TODO comment after fixing
-- If it touches a deprecated pattern from `patterns.yaml`, do a full migration for that usage (not just the TODO line)
-- Run relevant tests after each fix: `swift test`, `npm test`, `pytest`, etc.
+**Missing implementation:** Write the implementation inline. If non-trivial, write a minimal version that passes tests, then note what remains.
+
+**Temporary workaround:** Find the root cause. If fixable in <30 min: fix it. If not: add a comment explaining why it's not trivially fixable and what the proper fix would require.
+
+**Deprecated API usage:** Check if a newer API exists. If yes: migrate the callsite. If no replacement exists: mark as `needs-decision` and skip.
+
+**Missing error handling:** Add the error case. Pattern: check → log → return safe default or raise.
+
+```
+// BEFORE
+// TODO: handle empty response
+const data = response.json()
+
+// AFTER
+const data = response.json()
+if (!data || Object.keys(data).length === 0) {
+  console.warn('Empty response from', url)
+  return null
+}
+```
+
+**Multi-file fix:** If fixing one TODO requires changes across multiple files, fix them all atomically in the same commit. Do not leave a partial fix in place.
+
+After each fix: remove the TODO comment, run relevant tests (`swift test`, `npm test`, `pytest`, etc.), verify tests pass before moving to the next item.
 
 ### 2d. Commit per logical group
 
-Don't batch unrelated fixes into one commit. Group by theme:
+Don't batch unrelated fixes into one commit. Group by theme (cluster from 1c):
 
 ```bash
 git commit -m "refactor: migrate LoginService + UserService to async/await (resolves 3 TODOs)"
 ```
+
+If a TODO was classified as not fixable, document why in the commit message or skip it and include in the report's Skipped section.
 
 ## Phase 3: Report
 


### PR DESCRIPTION
## Summary

Content gap fills for the 6 thinnest/most incomplete skills. GLM-4.7 dispatched in parallel for #46, #49, #50; remainder implemented directly.

| Issue | Skill | Change |
|-------|-------|--------|
| #46 | calibrate | Added: Threshold Algorithm (cosine similarity, F1, 0.72-0.82 range), Error Handling (4 cases), Validation steps |
| #47 | retrieve | Added: Error Handling section (timeouts, 429 backoff, malformed YAML, partial failure, cursor corruption) |
| #48 | analyze | Added: Common Mistakes section (5 pitfalls with correct approach) |
| #49 | collab | Expanded: Workflow Templates — full YAML template structure, per-workflow descriptions, parallel execution semantics |
| #50 | knowledge-handoff | Expanded: Affected file analysis — risk table by path pattern, impact breadth, coupling detection, example output |
| #51 | todo-killer | Expanded: Phase 2 Fix — HOW-TO by TODO type, before/after example, multi-file fix handling, commit templates |

## Test plan
- [x] `bash tests/test-config.sh` — 109 passed, 0 failed

Fixes #46
Fixes #47
Fixes #48
Fixes #49
Fixes #50
Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)