### PR TITLE
feat: add xgh:glm skill and model-mapping shared reference

### DIFF
--- a/skills/_shared/references/model-mapping.md
+++ b/skills/_shared/references/model-mapping.md
@@ -1,0 +1,77 @@
+# Model Mapping Reference
+
+Canonical mappings from friendly model names to CLI-specific model formats.
+
+## Purpose
+
+When users mention models in natural language ("use GLM 4.7", "with GPT-5.4", "via Claude Opus"), dispatch skills need to:
+1. Detect the model mention
+2. Map it to the CLI's expected format
+3. Pass it as a parameter to the driver agent
+
+## Mappings by CLI
+
+### OpenCode (`--model provider/name`)
+
+| Friendly Name | OpenCode Format |
+|--------------|-----------------|
+| GLM 5, GLM-5 | `zai-coding-plan/glm-5` |
+| GLM 5 Turbo, GLM-5-Turbo | `zai-coding-plan/glm-5-turbo` |
+| GLM 4.7, GLM-4.7 | `zai-coding-plan/glm-4.7` |
+| Claude Opus 4.6, Opus, claude-opus | `anthropic/claude-opus-4-6` |
+| Claude Sonnet 4.6, Sonnet, claude-sonnet | `anthropic/claude-sonnet-4-6` |
+| GPT 5.4, GPT-5.4 | `openai/gpt-5.4` |
+| GPT 5.4 Mini, GPT-5.4-mini | `openai/gpt-5.4-mini` |
+
+### Codex (`-m <model>`)
+
+| Friendly Name | Codex Format |
+|--------------|--------------|
+| GPT 5.4, GPT-5.4 | `gpt-5.4` (default) |
+| GPT 5.4 Mini, GPT-5.4-mini | `gpt-5.4-mini` |
+| GPT 5.3 Codex | `gpt-5.3-codex` |
+| GPT 5.1 Codex Max | `gpt-5.1-codex-max` |
+| GPT 5.1 Codex Mini | `gpt-5.1-codex-mini` |
+| o3, o3-preview | `o3` |
+
+### Gemini (via `--model` flag)
+
+| Friendly Name | Gemini Format |
+|--------------|---------------|
+| Gemini 2.5 Pro | `gemini-2.5-pro` |
+| Gemini 2.5 Flash | `gemini-2.5-flash` |
+| Gemini 2.0 Flash | `gemini-2.0-flash` |
+
+## Detection Patterns
+
+Model mentions typically appear as:
+- "with <model>" → "with GLM 4.7"
+- "using <model>" → "using GPT-5.4"
+- "via <model>" → "via Claude Opus"
+- "<model> please" → "GLM 4.7 please"
+- "use <model>" → "use GPT-5.4"
+
+## Routing Logic
+
+When a model is detected:
+
+1. **Determine CLI from model name:**
+   - GLM models → OpenCode (Z.AI Coding Plan)
+   - GPT models → Codex or OpenCode (user preference)
+   - Claude models → OpenCode or Codex (user preference)
+   - Gemini models → Gemini CLI
+
+2. **Map to CLI format:**
+   - Use the table above to translate friendly name to CLI flag
+
+3. **Route to appropriate skill:**
+   - Pass the mapped model format to the driver agent
+
+## Example Transformations
+
+| User Input | Detected Model | CLI | Model Flag |
+|-----------|---------------|-----|------------|
+| "review this with GLM 4.7" | GLM 4.7 | OpenCode | `--model zai-coding-plan/glm-4.7` |
+| "implement using GPT-5.4" | GPT-5.4 | Codex | `-m gpt-5.4` |
+| "code review via Claude Opus" | Claude Opus | OpenCode | `--model anthropic/claude-opus-4-6` |
+| "dispatch to gemini: fix the bug" | (default) | Gemini | (none, use default) |

--- a/skills/glm/glm.md
+++ b/skills/glm/glm.md
@@ -1,0 +1,167 @@
+---
+name: xgh:glm
+description: "This skill should be used when the user asks to \"dispatch to glm\", \"run glm\", \"glm exec\", \"glm review\", \"use glm for\", \"send to glm\", or wants to delegate implementation or code review tasks to Z.AI's GLM models via OpenCode CLI. Supports worktree-isolated parallel dispatch and same-directory sequential dispatch."
+---
+
+> **Context-mode:** This skill primarily runs Bash commands. Use Bash directly for git
+> and opencode commands (short output). Use `Read` to review opencode output files.
+
+## Preamble — Execution mode
+
+Follow the shared execution mode protocol in `skills/_shared/references/execution-mode-preamble.md`. Apply it to this skill's command name.
+
+- `<SKILL_NAME>` = `glm`
+- `<SKILL_LABEL>` = `GLM dispatch`
+
+---
+
+# xgh:glm -- GLM Model Dispatch via OpenCode
+
+Dispatch implementation tasks or code reviews to Z.AI's GLM models through OpenCode CLI. GLM runs non-interactively via `opencode run "<prompt>"` with `--model zai-coding-plan/glm-*`, optionally in an isolated git worktree for safe parallel work alongside Claude Code.
+
+> This is a **convenience wrapper** around `xgh:opencode` that pre-configures GLM models. For advanced usage, use `/xgh-opencode` directly.
+
+## Prerequisites
+
+Check OpenCode CLI availability and z.ai configuration:
+
+```bash
+command -v opencode >/dev/null 2>&1 && opencode --version || echo "NOT_INSTALLED"
+```
+
+If `NOT_INSTALLED`, print: "OpenCode CLI not found. Install with: `npm i -g opencode-ai`" and stop.
+
+Check z.ai coding plan configuration:
+
+```bash
+opencode auth list | grep -i "zai" || echo "ZAI_NOT_CONFIGURED"
+```
+
+If `ZAI_NOT_CONFIGURED`, print: "Z.AI Coding Plan not configured. Run: `opencode auth login` and select Z.AI Coding Plan" and stop.
+
+## Input Parsing
+
+Parse the user's request to determine dispatch parameters. Only extract what the user explicitly provides — all other flags stay at defaults.
+
+**Spawning management flags** (always injected by the skill):
+
+| Flag | Purpose |
+|------|---------|
+| `--model zai-coding-plan/<model>` | GLM model selection (injected based on user preference) |
+| `cd <dir>` | Working directory (worktree path or current dir) — set via shell cd |
+| `> <output>` | Capture output via redirect (shell redirect) |
+
+**User-controlled parameters** (only injected if the user explicitly provides them):
+
+| Parameter | Default | User flag |
+|-----------|---------|-----------|
+| `type` | `exec` | first arg: `exec` or `review` |
+| `isolation` | `worktree` (exec), `same-dir` (review) | `--worktree`, `--same-dir` |
+| `prompt` | — | remaining text after type |
+| `model` | `glm-4.7` | `--model <name>` (e.g., `--model glm-5`, `--model glm-4.7`) |
+| `effort` | CLI default | `--effort <level>` (maps to model selection) |
+
+**Effort level to model mapping:**
+
+| User says | Resolves to |
+|-----------|-------------|
+| `--effort low` / `--effort medium` | `zai-coding-plan/glm-4.7` |
+| `--effort high` / `--effort max` | `zai-coding-plan/glm-5` |
+| `--effort turbo` | `zai-coding-plan/glm-5-turbo` |
+| `--model glm-4.7` | `zai-coding-plan/glm-4.7` |
+| `--model glm-5` | `zai-coding-plan/glm-5` |
+| `--model glm-5-turbo` | `zai-coding-plan/glm-5-turbo` |
+
+**Passthrough flags** (forwarded verbatim to OpenCode CLI):
+
+| Flag | What it controls |
+|------|-----------------|
+| `--attach <url>` | Attach to running OpenCode server (performance) |
+| `--format json` | Output as JSON events |
+| `--title <title>` | Session title |
+
+---
+
+## Step 1: Setup Workspace
+
+Follow `skills/_shared/references/dispatch-template.md` Step 1. Use `<CLI>` = `opencode`, `<CLI_LABEL>` = `GLM`.
+
+Same-dir fallback flag: `--same-dir`.
+
+---
+
+## Step 2: Dispatch
+
+### Build command
+
+Map user's model choice to full OpenCode model path, then dispatch:
+
+```bash
+# Model mapping (default: glm-4.7)
+MODEL_MAP=(
+    ["glm-4.7"]="zai-coding-plan/glm-4.7"
+    ["glm-5"]="zai-coding-plan/glm-5"
+    ["glm-5-turbo"]="zai-coding-plan/glm-5-turbo"
+)
+
+# Resolve model
+MODEL="${MODEL_MAP[$USER_MODEL]:-zai-coding-plan/glm-4.7}"
+
+OUTPUT_FILE="/tmp/glm-exec-${TIMESTAMP}.md"
+cd "$WORK_DIR" && opencode run --model "$MODEL" "$PROMPT" $PASSTHROUGH_FLAGS > "$OUTPUT_FILE" 2>&1
+```
+
+- **Worktree mode:** Run via Bash with `run_in_background: true`. Claude Code is free to continue other work while GLM runs.
+- **Same-dir mode:** Run synchronously. Claude Code waits for completion.
+
+### Review dispatch
+
+```bash
+OUTPUT_FILE="/tmp/glm-review-${TIMESTAMP}.md"
+cd "$WORK_DIR" && opencode run --model "$MODEL" "Code review: $PROMPT. Analyze the code and provide detailed feedback. Do NOT modify any files." $PASSTHROUGH_FLAGS > "$OUTPUT_FILE" 2>&1
+```
+
+---
+
+## Step 3: Collect Results
+
+Follow `skills/_shared/references/dispatch-template.md` Step 3. Use `<CLI_LABEL>` = `GLM`.
+
+---
+
+## Step 4: Integration (worktree mode only)
+
+Follow `skills/_shared/references/dispatch-template.md` Step 4.
+
+---
+
+## Step 5: Curate (if lossless-claude available)
+
+Follow `skills/_shared/references/dispatch-template.md` Step 5. Use `<CLI_LABEL>` = `GLM`, `<cli>` = `opencode`.
+
+---
+
+## Model Selection
+
+| Model | When to use |
+|-------|-------------|
+| `glm-4.7` (default) | Stable, reliable GLM model |
+| `glm-5` | Latest frontier GLM model |
+| `glm-5-turbo` | Faster variant of GLM-5 |
+
+## Sandbox Policy
+
+| Mode | Approach | Rationale |
+|------|----------|-----------|
+| Worktree exec | non-interactive auto-approves | Isolated directory, safe for auto-approve |
+| Same-dir exec | non-interactive auto-approves | User explicitly chose same-dir |
+| Review | prompt-engineered "Do NOT modify files" | No native read-only sandbox flag |
+
+## Anti-Patterns
+
+See shared anti-patterns in `skills/_shared/references/dispatch-template.md`.
+
+GLM-specific additions:
+- **Vague prompts.** GLM works best with focused, specific tasks. "Add unit tests for the TokenBucket.consume() method in src/lib/token-bucket.ts" will succeed where "Fix all the bugs" will not.
+- **Review without prompt constraint.** Always include 'Do NOT modify any files' in review prompts — no native read-only sandbox flag.
+- **Using z.ai API directly.** Always dispatch through OpenCode CLI to ensure coding plan quota applies correctly.


### PR DESCRIPTION
## Summary

- Adds `xgh:glm` skill — convenience wrapper around `xgh:opencode` that pre-configures Z.AI GLM models. Supports worktree-isolated exec, same-dir exec, and review modes with effort-to-model mapping (`glm-4.7` / `glm-5` / `glm-5-turbo`)
- Adds `skills/_shared/references/model-mapping.md` — shared reference for translating friendly model names to CLI-specific formats across OpenCode, Codex, and Gemini CLI

## Design

- `xgh:glm` delegates entirely to shared templates (`dispatch-template.md`, `execution-mode-preamble.md`) — no duplication
- `model-mapping.md` is a reference document for dispatch skills to look up friendly-name → CLI format conversions

## Test plan

- [x] `bash tests/test-config.sh` → 109 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)