### PR TITLE
fix: register xgh hooks in plugin.json and verify in doctor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,5 +15,29 @@
     "workflow",
     "cockpit",
     "devtools"
-  ]
+  ],
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.sh\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/skills/doctor/doctor.md
+++ b/skills/doctor/doctor.md
@@ -207,11 +207,32 @@ Validate the trigger engine configuration and runtime state.
    - Report triggers that fired in the last 24h
    - ⚠️ if any trigger has `fire_count > 10` with backoff — may be stuck in backoff loop
 
-4. **Hook registration** — check if PostToolUse hook is active:
-   - Run `claude config list` and check for post-tool-use hook
-   - ✅ PostToolUse hook registered (local command triggers will work)
+4. **Hook registration** — check if xgh hooks are active in settings.json:
+
+```python
+import json, os
+results = {}
+for f in [os.path.expanduser('~/.claude/settings.json'),
+          '.claude/settings.local.json']:
+    if not os.path.isfile(f): continue
+    d = json.load(open(f))
+    hooks = d.get('hooks', {})
+    for event, entries in hooks.items():
+        for entry in entries:
+            for h in entry.get('hooks', []):
+                cmd = h.get('command', '')
+                if 'xgh' in cmd and 'session-start' in cmd:
+                    results['SessionStart'] = True
+                if 'xgh' in cmd and 'post-tool-use' in cmd:
+                    results['PostToolUse'] = True
+print('xgh_session_start=' + str(results.get('SessionStart', False)).lower())
+print('xgh_post_tool_use=' + str(results.get('PostToolUse', False)).lower())
+```
+
+   - ✅ Both hooks registered — context injection and local triggers active
+   - ⚠️ SessionStart hook not found — context tree won't inject at session start.
    - ⚠️ PostToolUse hook not found — `source: local` triggers won't fire automatically.
-     Run `/xgh-setup` to configure.
+   - **Fix (either hook missing):** Reinstall the xgh plugin: `claude plugin install xgh@extreme-go-horse`
 
 5. **Example output:**
    ```
@@ -220,7 +241,8 @@ Validate the trigger engine configuration and runtime state.
    ✅ 4 triggers (3 enabled, 1 disabled)
    ⚠️ pr-stale-reminder: silenced until 2026-03-22T09:00:00Z
    ✅ Fired last 24h: p0-alert (2 times)
-   ⚠️ PostToolUse hook not registered — source:local triggers inactive
+   ✅ xgh SessionStart hook registered
+   ✅ xgh PostToolUse hook registered
    ```
 
 ### Check 8 — Agent version parity


### PR DESCRIPTION
## Summary

- **Root cause found**: `plugin.json` had no `hooks` section, so Claude Code never registered xgh's `session-start.sh` or `post-tool-use.sh` hooks into settings.json on plugin install. This is why SessionStart was missing (#90).
- **Fix**: Add `hooks` block to `.claude-plugin/plugin.json` using `${CLAUDE_PLUGIN_ROOT}` paths — same pattern lcm uses. Claude Code merges these on install without touching other plugins' hooks (no overwrite risk).
- **Code audit**: Confirmed xgh never writes `settings.json` — hooks/ scripts only read stdin, doctor.md only reads settings.json.
- **Doctor update**: Check 7 hook registration now parses `settings.json` directly (was using `claude config list` which doesn't work); added SessionStart alongside PostToolUse check; fix instruction updated to `claude plugin install xgh@extreme-go-horse`.

## Hooks declared

| Event | Script | Matcher |
|-------|--------|---------|
| `SessionStart` | `hooks/session-start.sh` | `""` (all) |
| `PostToolUse` | `hooks/post-tool-use.sh` | `"Bash"` |

`prompt-submit.sh` is intentionally omitted — it's a no-op (`echo '{}'`) with no functional value.

## Test plan

- [x] `bash tests/test-config.sh` — 109 passed, 0 failed
- [x] `bash tests/test-json-syntax.sh` — 19 passed, 0 failed

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)