### PR TITLE
fix: skip re-request when reviewer already in requested_reviewers (#113)

### DIFF
--- a/agents/pr-poller.md
+++ b/agents/pr-poller.md
@@ -153,10 +153,11 @@ To check if an active_agent is still running: examine its return status from pre
 ```bash
 REVIEWER_SLUG="${reviewer%\[bot\]}"
 pending=$(gh api repos/<REPO>/pulls/<PR>/requested_reviewers \
-  --jq '[.users[].login, .teams[].slug] | any(. == "'"$REVIEWER_SLUG"'")')
+  --arg reviewer_slug "$REVIEWER_SLUG" \
+  --jq '([.users[].login, .teams[].slug] | map(gsub("\\[bot\\]"; "")) | any(. == $reviewer_slug))')
 if [ "$pending" = "true" ]; then
   echo "Reviewer already pending — skipping re-request"
-  # skip to next PR; do NOT update last_review_request_at
+  continue  # skip to next PR; do NOT update last_review_request_at
 fi
 ```
 


### PR DESCRIPTION
## Summary

- Guard added before the review re-request cycle in `xgh:pr-poller` Step 4
- Checks `GET /pulls/{pr}/requested_reviewers` — if reviewer is already pending, skips DELETE+POST entirely
- Applies to both the `gh pr edit` (GitHub/Copilot) and `gh api` (other providers) paths

Fixes #113

## Test plan

- [x] `bash tests/test-config.sh` — 109 passed, 0 failed
- [x] `bash tests/test-file-refs.sh` — 35 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)