### PR TITLE
fix: use --squash in /release skill

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -28,7 +28,7 @@ Argument: $ARGUMENTS (default: patch)
    ```
    gh pr create --base main --title "Release v<new_version>" --body "Bump version to <new_version> for npm publish."
    ```
-8. Merge the PR: `gh pr merge --merge --delete-branch`
+8. Merge the PR: `gh pr merge --squash --delete-branch`
 
 ### Wait for release
 


### PR DESCRIPTION
## Summary

- Main branch only allows squash merges — `--merge` fails with `GraphQL: Merge commits are not allowed`
- Updates `/release` skill to use `--squash` instead

## Test plan

- [x] Discovered during v2.2.2 release — `--merge` failed, `--squash` worked

🤖 Generated with [Claude Code](https://claude.com/claude-code)