### PR TITLE
feat: SessionStart preference injection hook (Epic 0.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,6 +26,15 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-preferences.sh\""
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/hooks/session-start-preferences.sh
+++ b/hooks/session-start-preferences.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# hooks/session-start-preferences.sh — SessionStart preference injection
+# Epic 0.1: Builds a compact preference index from config/project.yaml
+# and injects it as additionalContext at session start.
+#
+# Coexistence contract: LAST in the SessionStart hook array.
+# Output: JSON with `additionalContext` key containing the preference index.
+set -euo pipefail
+
+# Locate project root (walk up from cwd)
+_find_project_root() {
+  local dir
+  dir="$(pwd)"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/config/project.yaml" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+PROJECT_ROOT=""
+if ! PROJECT_ROOT=$(_find_project_root 2>/dev/null); then
+  # No project.yaml found — skip injection silently
+  exit 0
+fi
+
+PROJ_YAML="${PROJECT_ROOT}/config/project.yaml"
+
+python3 - "$PROJ_YAML" "$PROJECT_ROOT" << 'PYEOF'
+import sys, os, json, subprocess
+
+proj_yaml = sys.argv[1]
+project_root = sys.argv[2]
+
+# --- YAML reader (yq primary, Python fallback) ---
+def read_yaml_field(yaml_path, yq_expr):
+    """Read a field using yq, falling back to Python yaml.safe_load."""
+    try:
+        result = subprocess.run(
+            ["yq", yq_expr, yaml_path],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            val = result.stdout.strip()
+            if val and val not in ("null", "~", ""):
+                return val
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    # Python fallback
+    try:
+        import yaml
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f) or {}
+        # Navigate the expression: convert '.preferences.pr.repo' to key chain
+        keys = [k for k in yq_expr.strip(".").split(".") if k]
+        val = data
+        for k in keys:
+            if isinstance(val, dict):
+                val = val.get(k)
+            else:
+                val = None
+            if val is None:
+                return ""
+        return str(val) if val is not None else ""
+    except Exception:
+        return ""
+
+def load_yaml_full(yaml_path):
+    """Load full YAML as dict using yq (JSON output) or Python fallback."""
+    try:
+        result = subprocess.run(
+            ["yq", "-o=json", ".", yaml_path],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        pass
+    try:
+        import yaml
+        with open(yaml_path) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return None
+
+# --- Load YAML ---
+if not os.path.isfile(proj_yaml):
+    sys.exit(0)
+
+data = load_yaml_full(proj_yaml)
+if data is None:
+    # Malformed YAML — warn once and skip
+    warning = (
+        "[xgh] WARNING: config/project.yaml has syntax errors — "
+        "preferences disabled this session. "
+        "Run 'yq . config/project.yaml' to diagnose."
+    )
+    print(json.dumps({"additionalContext": warning}))
+    sys.exit(0)
+
+prefs = data.get("preferences", {})
+
+# --- Current branch ---
+branch = ""
+try:
+    r = subprocess.run(
+        ["git", "-C", project_root, "branch", "--show-current"],
+        capture_output=True, text=True, timeout=5
+    )
+    if r.returncode == 0:
+        branch = r.stdout.strip()
+except Exception:
+    pass
+
+# --- Build domain lines (only domains with values) ---
+lines = []
+
+# PR domain — use load_pr_pref cascade (branch override > default > probe)
+pr = prefs.get("pr", {})
+branches = pr.get("branches", {})
+branch_pr = branches.get(branch, {}) if branch else {}
+if pr:
+    fields = {}
+    for field in ["repo", "provider", "reviewer", "merge_method"]:
+        val = branch_pr.get(field) or pr.get(field) or ""
+        if val:
+            fields[field] = str(val)
+    if fields:
+        parts = " ".join(f"{k}={v}" for k, v in fields.items())
+        lines.append(f"pr: {parts}")
+
+# Dispatch domain
+dispatch = prefs.get("dispatch", {})
+if dispatch:
+    fields = {}
+    for field in ["default_agent", "exec_effort"]:
+        val = dispatch.get(field, "")
+        if val:
+            fields[field] = str(val)
+    if fields:
+        parts = " ".join(f"{k}={v}" for k, v in fields.items())
+        lines.append(f"dispatch: {parts}")
+
+# Superpowers domain
+superpowers = prefs.get("superpowers", {})
+if superpowers:
+    fields = {}
+    for field in ["implementation_model", "review_model", "effort"]:
+        val = superpowers.get(field, "")
+        if val:
+            fields[field] = str(val)
+    if fields:
+        parts = " ".join(f"{k}={v}" for k, v in fields.items())
+        lines.append(f"superpowers: {parts}")
+
+# VCS domain
+vcs = prefs.get("vcs", {})
+if vcs:
+    fields = {}
+    for field in ["commit_format", "branch_naming"]:
+        val = vcs.get(field, "")
+        if val:
+            fields[field] = str(val)
+    if fields:
+        parts = " ".join(f"{k}={v}" for k, v in fields.items())
+        lines.append(f"vcs: {parts}")
+
+# Agents domain
+agents = prefs.get("agents", {})
+if agents:
+    val = agents.get("default_model", "")
+    if val:
+        lines.append(f"agents: default_model={val}")
+
+# Skip injection if no domains have values
+if not lines:
+    sys.exit(0)
+
+# --- Count pending preferences ---
+import glob as _glob
+pending_files = _glob.glob(os.path.join(project_root, ".xgh", "pending-preferences-*.yaml"))
+pending_count = len(pending_files)
+
+# --- Assemble output ---
+header = f"[xgh preferences] branch={branch}" if branch else "[xgh preferences]"
+body = "\n".join(lines)
+footer = f"Pending preferences: {pending_count}"
+additional_context = f"{header}\n{body}\n{footer}"
+
+print(json.dumps({"additionalContext": additional_context}))
+PYEOF

--- a/tests/test-session-start-preferences.sh
+++ b/tests/test-session-start-preferences.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# tests/test-session-start-preferences.sh
+# Tests for hooks/session-start-preferences.sh (Epic 0.1)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${REPO_ROOT}/hooks/session-start-preferences.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+run_hook() {
+  # Run from repo root so project.yaml is discoverable
+  (cd "$REPO_ROOT" && bash "$HOOK" 2>/dev/null)
+}
+
+echo "=== test-session-start-preferences ==="
+
+# Test 1: Outputs valid JSON
+echo "--- 1. Valid JSON output ---"
+output=$(run_hook)
+if python3 -c "import sys,json; json.loads(sys.argv[1])" "$output" 2>/dev/null; then
+  pass "output is valid JSON"
+else
+  fail "output is not valid JSON: $output"
+fi
+
+# Test 2: Contains additionalContext key
+echo "--- 2. additionalContext key present ---"
+if python3 -c "
+import sys, json
+d = json.loads(sys.argv[1])
+assert 'additionalContext' in d, 'missing additionalContext'
+" "$output" 2>/dev/null; then
+  pass "additionalContext key present"
+else
+  fail "additionalContext key missing. Output: $output"
+fi
+
+# Test 3: Contains [xgh preferences] header
+echo "--- 3. Preference header in output ---"
+if python3 -c "
+import sys, json
+d = json.loads(sys.argv[1])
+ctx = d.get('additionalContext', '')
+assert '[xgh preferences]' in ctx, 'header missing'
+" "$output" 2>/dev/null; then
+  pass "[xgh preferences] header present"
+else
+  fail "[xgh preferences] header missing. Context: $(python3 -c "import sys,json; print(json.loads(sys.argv[1]).get('additionalContext',''))" "$output" 2>/dev/null)"
+fi
+
+# Test 4: PR domain is included with expected fields
+echo "--- 4. PR domain fields ---"
+if python3 -c "
+import sys, json
+d = json.loads(sys.argv[1])
+ctx = d.get('additionalContext', '')
+assert 'pr:' in ctx, 'pr domain missing'
+assert 'repo=' in ctx, 'repo field missing'
+assert 'merge_method=' in ctx, 'merge_method field missing'
+" "$output" 2>/dev/null; then
+  pass "PR domain present with repo and merge_method"
+else
+  fail "PR domain missing or incomplete. Context: $(python3 -c "import sys,json; print(json.loads(sys.argv[1]).get('additionalContext',''))" "$output" 2>/dev/null)"
+fi
+
+# Test 5: dispatch domain present
+echo "--- 5. Dispatch domain ---"
+if python3 -c "
+import sys, json
+d = json.loads(sys.argv[1])
+ctx = d.get('additionalContext', '')
+assert 'dispatch:' in ctx, 'dispatch domain missing'
+" "$output" 2>/dev/null; then
+  pass "dispatch domain present"
+else
+  fail "dispatch domain missing. Context: $(python3 -c "import sys,json; print(json.loads(sys.argv[1]).get('additionalContext',''))" "$output" 2>/dev/null)"
+fi
+
+# Test 6: superpowers domain present
+echo "--- 6. Superpowers domain ---"
+if python3 -c "
+import sys, json
+d = json.loads(sys.argv[1])
+ctx = d.get('additionalContext', '')
+assert 'superpowers:' in ctx, 'superpowers domain missing'
+" "$output" 2>/dev/null; then
+  pass "superpowers domain present"
+else
+  fail "superpowers domain missing"
+fi
+
+# Test 7: Pending preferences count line present
+echo "--- 7. Pending preferences count ---"
+if python3 -c "
+import sys, json
+d = json.loads(sys.argv[1])
+ctx = d.get('additionalContext', '')
+assert 'Pending preferences:' in ctx, 'pending count missing'
+" "$output" 2>/dev/null; then
+  pass "Pending preferences count present"
+else
+  fail "Pending preferences count missing"
+fi
+
+# Test 8: Output is compact (under 500 chars — approx 120 tokens)
+echo "--- 8. Output token budget ---"
+char_count=$(python3 -c "
+import sys, json
+d = json.loads(sys.argv[1])
+ctx = d.get('additionalContext', '')
+print(len(ctx))
+" "$output" 2>/dev/null)
+if [ "$char_count" -lt 600 ]; then
+  pass "additionalContext is compact (${char_count} chars)"
+else
+  fail "additionalContext too long (${char_count} chars, want < 600)"
+fi
+
+# Test 9: Missing project.yaml — exits silently with no output
+echo "--- 9. Missing project.yaml exits silently ---"
+tmpdir=$(mktemp -d)
+output_no_yaml=$(cd "$tmpdir" && bash "$HOOK" 2>/dev/null || true)
+rmdir "$tmpdir"
+if [ -z "$output_no_yaml" ]; then
+  pass "no output when project.yaml missing"
+else
+  fail "unexpected output when project.yaml missing: $output_no_yaml"
+fi
+
+# Test 10: Malformed YAML — outputs warning in additionalContext
+echo "--- 10. Malformed YAML warning ---"
+tmpdir=$(mktemp -d)
+mkdir -p "${tmpdir}/config"
+echo ": broken: yaml: [" > "${tmpdir}/config/project.yaml"
+malformed_output=$(cd "$tmpdir" && bash "$HOOK" 2>/dev/null || true)
+rmdir_safe() { rm -rf "$1"; }
+if python3 -c "
+import sys, json
+if not sys.argv[1]:
+    sys.exit(0)  # empty is also OK (graceful skip)
+d = json.loads(sys.argv[1])
+ctx = d.get('additionalContext', '')
+assert 'WARNING' in ctx or ctx == '', 'should warn or be empty for malformed yaml'
+" "$malformed_output" 2>/dev/null; then
+  pass "malformed YAML handled gracefully"
+else
+  fail "malformed YAML not handled: $malformed_output"
+fi
+rm -rf "$tmpdir"
+
+# --- Summary ---
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ] && echo "ALL TESTS PASSED" && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- SessionStart hook that loads `config/project.yaml` and injects a compact preference index (~120 tokens) as `additionalContext`
- Covers PR, dispatch, superpowers, agents domains
- Counts pending preferences files
- Handles missing/malformed YAML gracefully

## Part of
Declarative Preferences Lifecycle — Phase 0 (Quick Wins)
Spec: #124

## Test plan
- [ ] 10-test suite passes (valid JSON, domain inclusion, token budget, error handling)
- [ ] Hook is LAST in SessionStart array (coexistence contract)
- [ ] Missing project.yaml = silent skip
- [ ] Malformed YAML = warning + skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)