### PR TITLE
feat: PreToolUse merge-method guard hook (Epic 0.3)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash hooks/pre-tool-use-preferences.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/pre-tool-use-preferences.sh
+++ b/hooks/pre-tool-use-preferences.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# hooks/pre-tool-use-preferences.sh — PreToolUse preference validation hook
+#
+# Epic 0.3: Validates merge methods and force-push on protected branches.
+# Reads stdin JSON: { tool_name, tool_input: { command } }
+# Outputs: JSON with additionalContext warning on mismatch, empty otherwise.
+#
+# Contract: NEVER blocks — only warns via additionalContext.
+# Any failure = silent pass-through (exit 0, no output).
+set -euo pipefail
+
+# ── Read stdin ──────────────────────────────────────────────────────────
+INPUT=$(cat 2>/dev/null) || exit 0
+[ -n "$INPUT" ] || exit 0
+
+# ── Fast exit: only Bash tool ───────────────────────────────────────────
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+
+# ── Extract command ─────────────────────────────────────────────────────
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "$COMMAND" ] || exit 0
+
+# ── Resolve repo root and source config reader ─────────────────────────
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+CONFIG_READER="${REPO_ROOT}/lib/config-reader.sh"
+PROJECT_YAML="${REPO_ROOT}/config/project.yaml"
+
+# ── Check 1: gh pr merge — merge method validation ─────────────────────
+if echo "$COMMAND" | grep -q 'gh pr merge'; then
+
+  # Extract merge method from command flags
+  CMD_METHOD=""
+  if echo "$COMMAND" | grep -qE -- '--squash'; then
+    CMD_METHOD="squash"
+  elif echo "$COMMAND" | grep -qE -- '--merge'; then
+    CMD_METHOD="merge"
+  elif echo "$COMMAND" | grep -qE -- '--rebase'; then
+    CMD_METHOD="rebase"
+  fi
+  # If no flag specified, we can't determine intent — pass through
+  [ -n "$CMD_METHOD" ] || exit 0
+
+  # Extract PR number from command (gh pr merge <number> or gh pr merge <url>)
+  PR_NUMBER=$(echo "$COMMAND" | grep -oE 'gh pr merge[[:space:]]+([0-9]+)' | grep -oE '[0-9]+' || true)
+
+  # Determine target branch
+  TARGET_BRANCH=""
+  if [ -n "$PR_NUMBER" ]; then
+    TARGET_BRANCH=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName 2>/dev/null || true)
+  fi
+
+  # Load configured merge method via config-reader.sh
+  CONFIGURED_METHOD=""
+  if [ -f "$CONFIG_READER" ] && [ -f "$PROJECT_YAML" ]; then
+    # shellcheck source=lib/config-reader.sh
+    source "$CONFIG_READER"
+    CONFIGURED_METHOD=$(load_pr_pref "merge_method" "" "$TARGET_BRANCH" 2>/dev/null || true)
+  fi
+
+  # If we couldn't determine the configured method, pass through
+  [ -n "$CONFIGURED_METHOD" ] || exit 0
+
+  # Compare
+  if [ "$CMD_METHOD" != "$CONFIGURED_METHOD" ]; then
+    BRANCH_MSG=""
+    if [ -n "$TARGET_BRANCH" ]; then
+      BRANCH_MSG=" for branch ${TARGET_BRANCH}"
+    fi
+
+    WARNING="[xgh] WARNING: merge method mismatch. Command uses --${CMD_METHOD} but config/project.yaml specifies ${CONFIGURED_METHOD}${BRANCH_MSG}. Consider using --${CONFIGURED_METHOD} instead."
+
+    jq -n --arg warning "$WARNING" '{
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": $warning
+      }
+    }'
+    exit 0
+  fi
+
+  # Match — pass through silently
+  exit 0
+fi
+
+# ── Check 2: git push --force on protected branches ────────────────────
+if echo "$COMMAND" | grep -qE 'git push.*(--force|-f)'; then
+
+  # Extract target branch from push command
+  # Patterns: git push origin main --force, git push -f origin main, git push --force
+  PUSH_BRANCH=""
+
+  # Try to extract remote and branch from the command
+  # Remove flags to find positional args: git push [remote] [refspec]
+  PUSH_ARGS=$(echo "$COMMAND" | sed 's/git push//' | sed 's/--force-with-lease//g' | sed 's/--force//g' | sed 's/-f//g' | sed 's/--no-verify//g' | xargs)
+
+  if [ -n "$PUSH_ARGS" ]; then
+    # Second positional arg is typically the branch (first is remote)
+    PUSH_BRANCH=$(echo "$PUSH_ARGS" | awk '{print $2}')
+    # Handle refspec like main:main
+    PUSH_BRANCH=$(echo "$PUSH_BRANCH" | sed 's/:.*//')
+  fi
+
+  # If no branch specified, try current branch
+  if [ -z "$PUSH_BRANCH" ]; then
+    PUSH_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  fi
+
+  [ -n "$PUSH_BRANCH" ] || exit 0
+
+  # Check if branch is protected in project.yaml
+  if [ -f "$PROJECT_YAML" ] && command -v python3 >/dev/null 2>&1; then
+    IS_PROTECTED=$(python3 -c "
+import yaml, sys
+branch = sys.argv[1]
+with open(sys.argv[2]) as f:
+    d = yaml.safe_load(f) or {}
+v = d.get('preferences',{}).get('pr',{}).get('branches',{}).get(branch,{}).get('protected', False)
+print(str(v).lower())
+" "$PUSH_BRANCH" "$PROJECT_YAML" 2>/dev/null || echo "false")
+
+    if [ "$IS_PROTECTED" = "true" ]; then
+      WARNING="[xgh] WARNING: force-push to protected branch '${PUSH_BRANCH}'. config/project.yaml marks this branch as protected. Consider using a non-force push or targeting a different branch."
+
+      jq -n --arg warning "$WARNING" '{
+        "hookSpecificOutput": {
+          "hookEventName": "PreToolUse",
+          "additionalContext": $warning
+        }
+      }'
+      exit 0
+    fi
+  fi
+
+  exit 0
+fi
+
+# ── No checks matched — silent pass-through ─────────────────────────────
+exit 0

--- a/tests/test-pre-tool-use-preferences.sh
+++ b/tests/test-pre-tool-use-preferences.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# tests/test-pre-tool-use-preferences.sh — Tests for PreToolUse preference validation hook
+#
+# Run: bash tests/test-pre-tool-use-preferences.sh
+set -euo pipefail
+
+HOOK="hooks/pre-tool-use-preferences.sh"
+PASS=0
+FAIL=0
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+assert_empty() {
+  local desc="$1" output="$2"
+  if [ -z "$output" ] || [ "$output" = "{}" ] || [ "$output" = "null" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc — expected empty/no output, got: $output"
+  fi
+}
+
+assert_contains() {
+  local desc="$1" output="$2" needle="$3"
+  if echo "$output" | grep -q "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc — expected to contain '$needle', got: $output"
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" output="$2" needle="$3"
+  if ! echo "$output" | grep -q "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc — expected NOT to contain '$needle', got: $output"
+  fi
+}
+
+assert_valid_json() {
+  local desc="$1" output="$2"
+  if [ -z "$output" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc (empty output is valid)"
+    return
+  fi
+  if echo "$output" | jq . >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc — invalid JSON: $output"
+  fi
+}
+
+run_hook() {
+  local input="$1"
+  echo "$input" | bash "$HOOK" 2>/dev/null || true
+}
+
+echo "=== PreToolUse Preferences Hook Tests ==="
+echo ""
+
+# ── Fast-exit tests ─────────────────────────────────────────────────────
+
+echo "--- Fast-exit tests ---"
+
+OUT=$(run_hook '{"tool_name": "Read", "tool_input": {"file_path": "/foo"}}')
+assert_empty "Non-Bash tool exits silently" "$OUT"
+
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "ls -la"}}')
+assert_empty "Bash without gh pr merge exits silently" "$OUT"
+
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "git status"}}')
+assert_empty "git status exits silently" "$OUT"
+
+OUT=$(run_hook '{}')
+assert_empty "Empty JSON exits silently" "$OUT"
+
+OUT=$(run_hook '')
+assert_empty "Empty input exits silently" "$OUT"
+
+OUT=$(run_hook 'not json')
+assert_empty "Invalid JSON exits silently" "$OUT"
+
+echo ""
+
+# ── Merge method tests ──────────────────────────────────────────────────
+# Note: These tests depend on config/project.yaml having:
+#   preferences.pr.merge_method: squash
+#   preferences.pr.branches.main.merge_method: merge
+#   preferences.pr.branches.develop.merge_method: squash
+
+echo "--- Merge method mismatch tests ---"
+
+# Test: --merge on a repo with default squash (no PR number = no branch lookup, uses default)
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge --merge"}}')
+assert_valid_json "Mismatch output is valid JSON" "$OUT"
+assert_contains "Default squash vs --merge warns" "$OUT" "mismatch"
+assert_contains "Warning mentions configured method" "$OUT" "squash"
+assert_not_contains "Never blocks" "$OUT" "decision"
+
+# Test: --squash on default (should match, no output)
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge --squash"}}')
+assert_empty "Default squash vs --squash passes silently" "$OUT"
+
+# Test: --rebase on default (mismatch)
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge 42 --rebase"}}')
+assert_valid_json "Rebase mismatch is valid JSON" "$OUT"
+assert_contains "Rebase vs squash warns" "$OUT" "mismatch"
+
+# Test: no merge flag specified (should pass through)
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge 42"}}')
+assert_empty "No merge flag passes silently" "$OUT"
+
+echo ""
+
+# ── Force-push tests ────────────────────────────────────────────────────
+
+echo "--- Force-push tests ---"
+
+# Note: force-push warnings depend on branches having protected: true in config.
+# Default project.yaml does NOT have protected: true, so these should pass silently.
+
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "git push --force origin feature-branch"}}')
+assert_empty "Force-push to unprotected branch passes silently" "$OUT"
+
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "git push -f origin feature-branch"}}')
+assert_empty "Short -f to unprotected branch passes silently" "$OUT"
+
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "git push origin main"}}')
+assert_empty "Non-force push to main passes silently" "$OUT"
+
+echo ""
+
+# ── Output format validation ────────────────────────────────────────────
+
+echo "--- Output format tests ---"
+
+OUT=$(run_hook '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge --rebase"}}')
+if [ -n "$OUT" ]; then
+  HAS_HOOK_EVENT=$(echo "$OUT" | jq -r '.hookSpecificOutput.hookEventName // empty' 2>/dev/null || true)
+  if [ "$HAS_HOOK_EVENT" = "PreToolUse" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: hookEventName is PreToolUse"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: hookEventName should be PreToolUse, got: $HAS_HOOK_EVENT"
+  fi
+
+  HAS_CONTEXT=$(echo "$OUT" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null || true)
+  if [ -n "$HAS_CONTEXT" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: additionalContext is present"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: additionalContext should be present"
+  fi
+else
+  FAIL=$((FAIL + 2))
+  echo "  FAIL: Expected mismatch output for --rebase"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- PreToolUse hook that validates `gh pr merge` commands against `config/project.yaml` merge method preferences
- Warns (never blocks) when merge method doesn't match configured preference for the target branch
- Also detects `git push --force` to protected branches
- Fast exits for non-Bash tools and non-matching commands
- Fully defensive: any failure = silent pass-through

## Part of
Declarative Preferences Lifecycle — Phase 0 (Quick Wins)
Spec: #124

## Test plan
- [ ] 19-test suite passes (fast exits, mismatch detection, match pass-through, force-push, output format)
- [ ] Hook is FIRST in PreToolUse array (coexistence contract)
- [ ] Non-Bash tools exit immediately with no output
- [ ] Non-merge commands exit immediately with no output
- [ ] Network failures = silent pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)