### PR TITLE
fix: use --squash in /release skill

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -28,7 +28,7 @@ Argument: $ARGUMENTS (default: patch)
    ```
    gh pr create --base main --title "Release v<new_version>" --body "Bump version to <new_version> for npm publish."
    ```
-8. Merge the PR: `gh pr merge --merge --delete-branch`
+8. Merge the PR: `gh pr merge --squash --delete-branch`
 
 ### Wait for release
 


### PR DESCRIPTION
## Summary

- The `/release` skill creates PRs targeting `main`, which only allows squash merges
- Updated the skill to use `--squash` merge method instead of default merge

## Test plan

- [x] Verified `main` branch protection requires squash merges
- [x] Confirmed `/release` skill now uses `--squash` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)