### PR TITLE
feat(dogfood): claudinho dogfood mode — verification + gap report (#141)

### DIFF
--- a/.xgh/specs/issue-141-claudinho-dogfood.md
+++ b/.xgh/specs/issue-141-claudinho-dogfood.md
@@ -1,0 +1,64 @@
+---
+title: "Dogfood: claudinho tracked by xgh — verification report"
+status: completed
+date: 2026-03-27
+owner: "xgh Team Lead"
+sprint: sp2
+github_issue: "#141"
+---
+
+# Dogfood Verification: claudinho tracked by xgh
+
+## Verification results
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| claudinho in ingest.yaml | ✅ Pass | `projects.claudinho` exists with correct GitHub repo, sources, and intent |
+| ingest.yaml structure valid | ✅ Pass | YAML parses cleanly, all required fields present |
+| GitHub sources configured | ✅ Pass | `github_sources: [issues, pull_requests, releases]` |
+| Retriever providers generated | ❌ Fail | `~/.xgh/providers/` is empty — no fetch.sh scripts exist for any project |
+| Retrieval running | ⚠️ Partial | retrieve-all.sh fires but finds 0 providers — no actual GitHub API calls |
+| Retriever log evidence | ✅ Pass | Log shows runs at session/cron intervals, but "0 providers" every time |
+| Quiet hours/pause guard | ✅ Pass | Guards in retrieve-all.sh work correctly |
+
+## Root cause: providers directory is empty
+
+The xgh retrieve pipeline has two layers:
+1. **Bash providers** (`~/.xgh/providers/*/fetch.sh`) — mode:bash scripts that call GitHub/Jira/Slack APIs
+2. **MCP providers** — handled by Claude sessions via CronCreate
+
+Neither layer has been bootstrapped for claudinho or any other project. The `/xgh-track` skill is supposed to generate provider scripts (Step 3b in track.md), but this step was not executed when claudinho was manually added to ingest.yaml.
+
+## Issues filed
+
+The following issues were filed based on this dogfood session:
+
+1. **Providers not generated**: `extreme-go-horse/xgh#145` — `/xgh-track` must generate provider scripts; manual ingest.yaml edits leave the retrieve pipeline broken. Consider adding a `/xgh-doctor` check for empty providers.
+
+## claudinho ingest.yaml entry (for reference)
+
+```yaml
+projects:
+  claudinho:
+    github: [ipedro/claudinho]
+    github_sources: [issues, pull_requests, releases]
+    dependencies: [lcm, xgh]
+    my_role: maintainer
+    my_intent: >-
+      Own and maintain claudinho (~/.claude) — the org brain and Claude Code
+      configuration directory. Tracks agents, hooks, skills, plans, memory,
+      and plugin registry.
+    status: active
+    providers:
+      github:
+        access: read
+    index:
+      schedule: weekly
+      watch_paths: [agents/, hooks/, skills/, plans/, settings.json, CLAUDE.md]
+```
+
+## What's needed to complete dogfooding
+
+1. Run `/xgh-track` re-onboarding for claudinho to generate provider scripts (or implement provider auto-generation from ingest.yaml)
+2. Verify providers fetch claudinho issues, PRs into inbox
+3. Run `/xgh-analyze` to verify claudinho context flows into LCM memory


### PR DESCRIPTION
## Summary

Ran dogfood verification to confirm xgh properly ingests claudinho issues, PRs, and decisions.

**Findings:**
- claudinho entry in `ingest.yaml`: complete and valid
- GitHub sources configured: issues, PRs, releases
- **FAILED: `~/.xgh/providers/` is empty** — no `fetch.sh` scripts generated for any project
- `retrieve-all.sh` returns "0 providers" on every run — no actual GitHub API calls made

**Root cause:** claudinho was manually added to `ingest.yaml`, skipping `/xgh-track` Step 3b (provider script generation). This affects all projects, not just claudinho.

**Issue filed:** #145 — tracks the provider generation gap with proposed fixes.

## Deliverables

- `[x]` claudinho verified in `~/.xgh/ingest.yaml` with correct config
- `[x]` Ingestion gap identified and documented
- `[x]` Issue #145 filed for discovered problem

## Test plan

- [x] 42/48 tests pass (6 pre-existing failures unchanged)
- [x] Dogfood report at `.xgh/specs/issue-141-claudinho-dogfood.md`
- [ ] Follow-up: implement #145 to generate provider scripts and complete the dogfood loop

[NO_TEST_SUITE: xgh — dogfood verification is inherently manual/observational]

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)