### PR TITLE
fix(providers): add /xgh-init-providers + empty-providers detection (#145)

### DIFF
--- a/commands/init-providers.md
+++ b/commands/init-providers.md
@@ -1,0 +1,25 @@
+---
+name: xgh-init-providers
+description: Generate provider scripts from ingest.yaml for all tracked projects with github access. Run this after manually editing ingest.yaml or when providers/ is empty.
+---
+
+# /xgh-init-providers — Generate Provider Scripts from ingest.yaml
+
+Run the `xgh:init-providers` skill to regenerate provider scripts from the current `~/.xgh/ingest.yaml`.
+
+## Usage
+
+```
+/xgh-init-providers
+```
+
+Run when:
+- `~/.xgh/user_providers/` is empty after manual edits to `ingest.yaml`
+- A new project was added to `ingest.yaml` without running `/xgh-track`
+- `/xgh-doctor` reports missing or stale providers
+
+## Related Skills
+
+- `xgh:init-providers` — the full workflow skill this command triggers
+- `xgh:track` — full interactive onboarding (generates providers as part of Step 3b)
+- `xgh:doctor` — Check 6 reports provider status and suggests running this command

--- a/skills/doctor/doctor.md
+++ b/skills/doctor/doctor.md
@@ -148,7 +148,32 @@ For each project with `github:` entries, check `index.last_full` against `index.
 
 ### Check 6 — Providers
 
-List all directories in `~/.xgh/user_providers/`. For each:
+**First: check for empty providers with tracked github repos (issue #145):**
+
+```python
+import yaml, os
+data = yaml.safe_load(open(os.path.expanduser('~/.xgh/ingest.yaml')))
+has_github = any(
+    p.get('providers', {}).get('github') and p.get('github', [])
+    for p in data.get('projects', {}).values()
+)
+providers_dir = os.path.expanduser('~/.xgh/user_providers')
+providers_empty = not any(
+    os.path.isdir(os.path.join(providers_dir, d))
+    for d in os.listdir(providers_dir)
+) if os.path.isdir(providers_dir) else True
+print(f'has_github={has_github}')
+print(f'providers_empty={providers_empty}')
+```
+
+If `has_github=True` and `providers_empty=True`:
+```
+✗ Providers: user_providers/ is empty but ingest.yaml has N projects with GitHub access
+  Fix: run /xgh-init-providers to generate provider scripts from ingest.yaml
+```
+This is the root cause of issue #145 — manual ingest.yaml edits bypass /xgh-track Step 3b.
+
+**Then: list all directories in `~/.xgh/user_providers/`. For each:**
 
 1. Check `provider.yaml` exists and read `mode`
 2. If `mode: cli`: check `fetch.sh` exists and is executable
@@ -173,7 +198,7 @@ ls ~/.xgh/providers/ 2>/dev/null
 If `~/.xgh/providers/` exists with non-empty subdirectories:
 ```
 ⚠ Legacy providers found in ~/.xgh/providers/
-  Run /xgh-track to migrate to ~/.xgh/user_providers/
+  Run /xgh-init-providers to migrate to ~/.xgh/user_providers/
 ```
 
 Also check `~/.xgh/tokens.env`:

--- a/skills/init-providers/init-providers.md
+++ b/skills/init-providers/init-providers.md
@@ -1,0 +1,132 @@
+---
+name: xgh:init-providers
+description: "This skill should be used when the user runs /xgh-init-providers, asks to 'regenerate providers', 'fix empty providers', 'providers directory is empty', or after manually editing ingest.yaml without running /xgh-track. Reads ingest.yaml and generates provider scripts in ~/.xgh/user_providers/ for all projects with github access."
+---
+
+# xgh:init-providers — Generate Provider Scripts from ingest.yaml
+
+Reads `~/.xgh/ingest.yaml` and generates or updates `provider.yaml` + `fetch.sh` in
+`~/.xgh/user_providers/` for all services currently in ingest.yaml. This is the
+repair path when providers were not generated (e.g., after a manual ingest.yaml edit
+that bypassed `/xgh-track` Step 3b).
+
+> **Persistence guarantee:** Only creates or updates providers for services explicitly
+> in ingest.yaml. Never deletes existing providers. If a provider already exists,
+> skip it (unless `--force` flag is passed).
+
+## Step 1 — Read ingest.yaml
+
+Parse `~/.xgh/ingest.yaml` and collect:
+
+```python
+import yaml
+data = yaml.safe_load(open(os.path.expanduser('~/.xgh/ingest.yaml')))
+projects = data.get('projects', {})
+
+# For each project with providers.github:
+github_repos = {}  # project_name -> {repos: [], sources: []}
+for project_name, project in projects.items():
+    if project.get('providers', {}).get('github'):
+        repos = project.get('github', [])
+        sources = project.get('github_sources', ['issues', 'pull_requests', 'releases'])
+        if repos:
+            github_repos[project_name] = {'repos': repos, 'sources': sources}
+```
+
+## Step 2 — Check existing providers
+
+```bash
+ls ~/.xgh/user_providers/ 2>/dev/null
+```
+
+For each service found:
+- Report: `⚠ provider already exists: <name> — skipping (use --force to overwrite)`
+
+## Step 3 — Generate github-cli provider
+
+If any projects have `providers.github` configured and `~/.xgh/user_providers/github-cli/` does
+not exist (or `--force` was passed):
+
+**Probe mode:**
+```bash
+command -v gh && gh auth status
+```
+- `gh` available and authenticated → use `mode: cli`
+- Otherwise → report error and suggest `gh auth login`
+
+**Generate `~/.xgh/user_providers/github-cli/provider.yaml`:**
+
+```yaml
+service: github
+mode: cli
+cursor_strategy: timestamp
+description: Fetches GitHub issues, pull requests, and releases for all tracked repos using gh CLI
+
+sources:
+  - project: <project_name>
+    repo: <github_repo>
+    types: <github_sources filtered to [issues, pull_requests, releases]>
+  # ... one entry per project with github repos
+```
+
+**Generate `~/.xgh/user_providers/github-cli/fetch.sh`:**
+
+The script must:
+1. Read `CURSOR_FILE` env var for incremental pagination (ISO timestamp)
+2. Default to 24h ago if no cursor exists
+3. For each repo in the provider, run `gh issue list`, `gh pr list`, `gh release list`
+   with `--json` and filter by `updatedAt > SINCE`
+4. Write each result to `$INBOX_DIR/<timestamp>_github_<repo_slug>_<type><number>.md`
+   with frontmatter:
+   ```
+   ---
+   type: inbox_item
+   source_type: github_<issue|pr|release>
+   source_repo: <owner/repo>
+   source_ts: <updatedAt>
+   project: <project_name>
+   urgency_score: 50
+   processed: false
+   awaiting_direction: null
+   links_followed: []
+   ---
+   ```
+5. Skip files that already exist in inbox (idempotent)
+6. Write `NEW_CURSOR` to `$CURSOR_FILE` on success
+7. Exit 0 on success, exit 1 on fatal errors, exit 2 on partial success
+
+Make `fetch.sh` executable: `chmod +x fetch.sh`
+
+## Step 4 — Validate
+
+Run the generated fetch.sh with a recent cursor:
+
+```bash
+CURSOR_FILE="/tmp/xgh_validate_cursor" \
+INBOX_DIR="$HOME/.xgh/inbox" \
+PROVIDER_DIR="$HOME/.xgh/user_providers/github-cli" \
+TOKENS_FILE="$HOME/.xgh/tokens.env" \
+bash "$HOME/.xgh/user_providers/github-cli/fetch.sh"
+```
+
+- Exit 0: report success + number of items fetched
+- Non-zero: show stderr, offer to retry or skip
+
+## Step 5 — Report
+
+```
+xgh init-providers
+══════════════════
+
+GitHub
+  ✓ github-cli created — N repos, cli mode
+    Repos: owner/repo1, owner/repo2, ...
+    Validated: fetched M items
+
+Summary: 1 provider created. Run /xgh-doctor to verify pipeline health.
+```
+
+If `user_providers/` was already populated with a valid github-cli provider:
+```
+  ⚠ github-cli already exists — skipping. Use /xgh-init-providers --force to regenerate.
+```


### PR DESCRIPTION
## Summary

- **Root cause** (issue #145): `ingest.yaml` was manually edited, bypassing `/xgh-track` Step 3b which generates provider scripts. `~/.xgh/user_providers/` was empty for all projects, so `retrieve-all.sh` found nothing to run and returned "0 providers" on every cycle.
- Add `/xgh-init-providers` command + skill — repair path that generates providers from `ingest.yaml` without full re-onboarding
- Update `doctor.md` Check 6 to detect empty `user_providers/` when `ingest.yaml` has github-tracked projects and suggest the fix command

## Files changed

| File | Change |
|------|--------|
| `commands/init-providers.md` | New `/xgh-init-providers` command |
| `skills/init-providers/init-providers.md` | New skill — generates `provider.yaml` + `fetch.sh` from `ingest.yaml` |
| `skills/doctor/doctor.md` | Check 6: detect empty providers + fix suggestion |

## Runtime fix (not in repo — user_providers/ is user-owned)

Created `~/.xgh/user_providers/github-cli/` with `provider.yaml` + `fetch.sh` covering all 9 tracked repos. Validated: fetched 52 items on first run (exit 0).

## Test plan

- [ ] Run `/xgh-doctor` — Check 6 should now report `✓ github-cli: 9 repos, cli mode`
- [ ] Run `/xgh-init-providers` on a clean install — should create `github-cli` provider and validate it
- [ ] Confirm `retrieve-all.sh` log shows > 0 providers on next cycle
- [ ] Adversarial review: Haiku Enthusiast + Haiku Adversary + Sonnet Judge ✅

## Adversarial review findings addressed

- Adversary found `local` keyword used outside a function in `releases` case of `fetch.sh` → fixed (renamed to `release_filename` without `local`)

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)