### PR TITLE
feat: SP4 Team Lead — frontmatter awareness (Sprint 1)

### DIFF
--- a/skills/_shared/references/agent-frontmatter.md
+++ b/skills/_shared/references/agent-frontmatter.md
@@ -1,0 +1,141 @@
+# Agent Frontmatter Reference
+
+Agent files in xgh use YAML frontmatter to declare metadata. Skills should read and respect this metadata when spawning or working with agents.
+
+## Frontmatter Schema
+
+```yaml
+---
+name: <string>                # Agent identifier (e.g., "code-reviewer")
+description: |                # Markdown description of agent usage
+  Multi-line description of when and why to use this agent.
+  Include examples if relevant.
+
+model: <string>               # Model: "haiku" | "sonnet" | "opus" | "sonnet4"
+                              # (default: from skill settings or sonnet)
+capabilities: [<string>]      # Semantic tags: [code-review, architecture, investigation, etc.]
+color: <string>               # UI color hint (default: default, or custom hex/name)
+tools: [<string>]             # List of available tools (Read, Grep, Bash, etc.)
+
+# Optional extended metadata
+effort: <string>              # "quick" | "moderate" | "intensive" (for planning)
+focus_area: <string>          # Domain: ios, backend, security, docs, etc.
+cost_model: <string>          # "efficient" | "balanced" | "thorough"
+---
+```
+
+## Reading Frontmatter in Skills
+
+When a skill needs to spawn or configure an agent, extract frontmatter:
+
+### 1. Extract YAML header
+
+```bash
+# Extract YAML frontmatter from agent file
+agent_file="$1"
+frontmatter=$(awk '/^---$/{flag=!flag;next}flag' "$agent_file" | head -20)
+```
+
+### 2. Parse key fields
+
+Use `yq` or native parsing:
+
+```bash
+name=$(echo "$frontmatter" | grep "^name:" | cut -d' ' -f2)
+model=$(echo "$frontmatter" | grep "^model:" | cut -d' ' -f2)
+capabilities=$(echo "$frontmatter" | grep "^capabilities:" | tr -d '[]' | sed 's/capability://g')
+```
+
+Or in Python:
+
+```python
+import yaml
+
+def read_agent_frontmatter(agent_file_path):
+    with open(agent_file_path) as f:
+        # Skip to frontmatter
+        if f.readline().strip() != "---":
+            return {}
+
+        # Read until closing ---
+        frontmatter_lines = []
+        for line in f:
+            if line.strip() == "---":
+                break
+            frontmatter_lines.append(line)
+
+        return yaml.safe_load("".join(frontmatter_lines)) or {}
+```
+
+### 3. Use in skill context
+
+When spawning an agent:
+
+```bash
+# Read frontmatter
+fm=$(read_agent_frontmatter "$agent_file")
+
+# Extract model, default to "sonnet"
+model=$(echo "$fm" | yq '.model // "sonnet"')
+
+# Extract capabilities for context
+capabilities=$(echo "$fm" | yq '.capabilities | join(", ")')
+
+# Pass to agent spawn with appropriate model
+spawn_agent --model "$model" --agent "$agent_file"
+```
+
+## Common Frontmatter Patterns
+
+| Field | Usage | Example |
+|-------|-------|---------|
+| `model` | Route to correct Claude version | `sonnet` for review, `haiku` for triage |
+| `capabilities` | Filter agents by skill type | Skill needs [code-review] → use code-reviewer agent |
+| `tools` | Predict what agent can access | Agent has [Bash] → can run shell commands |
+| `effort` | Time/cost estimation | "quick" agents for fast triage, "intensive" for deep review |
+| `focus_area` | Domain-specific routing | iOS skill → prefer ios-lead agent |
+
+## Team Lead Agent Metadata
+
+Team Lead agents extend the base schema with context:
+
+```yaml
+---
+name: team-lead
+description: "Orchestrator for [project-name]. Sets crons, manages project backlog, delegates work."
+model: sonnet
+capabilities: [orchestration, delegation, context-gathering]
+color: default
+tools: [Read, Grep, Bash, Skill]
+
+# Team Lead specific
+team_context:
+  project: xgh                    # Project this lead owns
+  repo_path: ~/Developer/xgh
+  github_project: "xgh — Development"
+  cron_retrieve: "*/30 * * * *"   # Retrieve interval
+  cron_analyze: "0 * * * *"       # Analyze interval
+
+on_spawn:
+  - setup_crons
+  - gather_context
+  - report_status
+---
+```
+
+Skills should read `team_context.project` and `on_spawn` to understand what the agent will do.
+
+## Skills Using Frontmatter
+
+These xgh skills should read and respect agent frontmatter:
+
+- **dispatch** — Route task to agent with matching capability + preferred model
+- **team** (agent-collaboration) — Spawn team lead agents, respecting on_spawn hooks
+- **ship-prs** — Find code-review agents, use preferred model
+- **implement** — Spawn implementation agents with correct effort level
+
+## Related Files
+
+- Agent definitions: `~/Developer/xgh/agents/*.md`
+- Base template: `~/.claude/org/team-lead-template.md`
+- Skill integration example: `~/Developer/xgh/skills/dispatch/dispatch.md`

--- a/skills/dispatch/dispatch.md
+++ b/skills/dispatch/dispatch.md
@@ -107,6 +107,35 @@ These values override the cold-start defaults but are superseded by profile data
 - `fallback_agent` → use as the cold-start agent when `detect-agents.sh` finds no installed agents
 - `exec_effort` / `review_effort` → apply as cold-start effort based on whether the task type is exec or review
 
+## Step 2.6: Read Agent Frontmatter
+
+If the task mentions a specific agent by name (e.g., "dispatch this to the code-reviewer agent"), or if an agent file is available in `agents/` directory:
+
+1. **Locate agent file:** Search `agents/<name>.md` where `<name>` is the mentioned agent or inferred from context
+2. **Extract YAML frontmatter** — parse the `---` block at the top of the file
+3. **Read metadata:**
+   - `model` — preferred Claude model (haiku, sonnet, opus, sonnet4)
+   - `capabilities` — semantic tags (code-review, investigation, orchestration, etc.)
+   - `effort` — effort level hint (quick, moderate, intensive)
+   - `tools` — list of available tools (affects what the agent can do)
+4. **Apply overrides** — if agent specifies a model, use it (unless user provided `--model` override)
+
+**Frontmatter reference:** See `skills/_shared/references/agent-frontmatter.md` for detailed schema.
+
+**Example:**
+```yaml
+# agents/code-reviewer.md
+---
+name: code-reviewer
+model: sonnet
+capabilities: [code-review, architecture, conventions]
+effort: moderate
+tools: [Read, Grep, Bash]
+---
+```
+
+When dispatching to this agent: prefer sonnet model, expect moderate effort, understand it can read code and run grep.
+
 ## Step 3: Select Agent + Model + Effort
 
 **If profile data exists:** Use the `{agent, model, effort}` tuple from Step 2.


### PR DESCRIPTION
Closes #134

## Summary
Implements Sprint 1 MVP for frontmatter awareness as per Option D hybrid design.

## What it does
- New shared reference: `skills/_shared/references/agent-frontmatter.md`
  - Documents YAML frontmatter schema for team lead agents
  - Shows Python/bash patterns for reading and parsing metadata
  - Lists common fields: model, capabilities, tools, effort, focus_area
  
- Updated dispatch skill with Step 2.6: Read Agent Frontmatter
  - Extract agent frontmatter when dispatching to specific agents
  - Respect declared model preference (haiku, sonnet, opus, sonnet4)
  - Use capability tags for routing validation
  - Apply effort hints for planning

## Design
Frontmatter format:
```yaml
---
name: code-reviewer
model: sonnet
capabilities: [code-review, architecture, conventions]
effort: moderate
tools: [Read, Grep, Bash]
focus_area: quality-assurance
---
```

## Next steps (Sprint 2)
- Apply frontmatter awareness to more skills: implement, ship-prs, review-pr
- Create `config/frontmatter-spec.yaml` with per-filetype schemas
- Create `skills/frontmatter/` validation skill
- Extend `/xgh-doctor` with frontmatter health check

## Test plan
- Verify dispatch skill correctly reads agent model preference
- Verify dispatch respects frontmatter model over cold-start default
- Verify capabilities tag filtering works

🤖 Generated with xgh Team Lead