### PR TITLE
fix: align package.json and marketplace.json to v2.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "repo": "extreme-go-horse/xgh"
       },
       "description": "Declare your agent behavior in YAML. Converge every AI platform to match.",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "strict": true
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreme-go-horse/xgh",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- `plugin.json` was bumped to 2.3.0 in the release commit but `package.json` and `marketplace.json` were left at 2.2.0
- Aligns all 3 version files to 2.3.0

## Test plan
- [x] Verify all 3 files show 2.3.0
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)