### PR TITLE
feat: demote 20 internal skills from prompt registration

### DIFF
--- a/skills/analyze/analyze.md
+++ b/skills/analyze/analyze.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:analyze
 description: "This skill should be used when the user runs /xgh-analyze, when invoked by the CronCreate scheduler, or when ~/.xgh/inbox/.urgent exists. Headless analyzer loop — reads ~/.xgh/inbox/, classifies content types, extracts structured memories, deduplicates against lossless-claude, writes to workspace or personal collection, manages TTL, and generates Obsidian-compatible daily digest."
+user_facing: false
 ---
 
 # xgh:analyze — Analysis Loop

--- a/skills/archive/archive.md
+++ b/skills/archive/archive.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:archive
 description: "Use this skill when the user runs /xgh-archive or /xgh-archive --obituary. Archives a file or feature by moving it to .xgh/archived/ with a timestamp prefix. With --obituary, also creates a GitHub issue labeled kind:decommission documenting what it did, why it was removed, what metric it failed to move, and who removed it — then stores the decision in LCM."
+user_facing: false
 ---
 
 # xgh:archive — Archive & Obituary Workflow

--- a/skills/briefing/briefing.md
+++ b/skills/briefing/briefing.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:briefing
 description: "This skill should be used when the user runs /xgh-briefing, /xgh-briefing compact, or /xgh-briefing focus, or asks for a morning briefing or session summary. Aggregates Slack, Jira, GitHub, Gmail, Calendar, Figma, and xgh team memory into a prioritized executive summary with a suggested focus."
+user_facing: false
 ---
 
 # xgh:briefing — Intelligent Session Briefing

--- a/skills/calibrate/calibrate.md
+++ b/skills/calibrate/calibrate.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:calibrate
 description: "Use when running /xgh-calibrate or asking to tune the dedup threshold. Calibrates similarity threshold against real lossless-claude memory pairs, computes F1 scores at multiple thresholds, and offers to update analyzer.dedup_threshold in ingest.yaml."
+user_facing: false
 ---
 
 # xgh:calibrate — Dedup Threshold Calibration

--- a/skills/coding-agents/coding-agents.md
+++ b/skills/coding-agents/coding-agents.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:coding-agents
 description: "Use when the user asks to \"/xgh-coding-agents\", wants to see available coding agents (OpenCode, Gemini), probe CLI capabilities, or refresh model mappings."
+user_facing: false
 ---
 
 # xgh:coding-agents — Coding Agent Management

--- a/skills/config/config-show.md
+++ b/skills/config/config-show.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:config-show
 description: "This skill should be used when the user runs /xgh-config show or asks to 'show preferences', 'show project config', 'what are the current preferences', 'show resolved config'. Displays all resolved preferences for the current branch from config/project.yaml, with source attribution (project default vs branch override) and a pending preferences count."
+user_facing: false
 ---
 
 # xgh:config-show — Display Resolved Project Preferences

--- a/skills/config/config.md
+++ b/skills/config/config.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:config
 description: "This skill should be used when the user runs /xgh-config or asks to 'edit config', 'configure project', 'add project to xgh'. Structured YAML editor for ~/.xgh/ingest.yaml — supports showing sections by dot-path, setting values with type validation, adding/removing projects interactively, and validating required fields."
+user_facing: false
 ---
 
 # xgh:config — Manifest Editor

--- a/skills/frontmatter/SKILL.md
+++ b/skills/frontmatter/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:frontmatter
 description: "This skill should be used when the user runs /xgh-frontmatter, asks to 'validate frontmatter', 'check frontmatter', 'fix frontmatter', 'audit file headers', or 'add missing frontmatter'. Validates YAML frontmatter in markdown files against the schema in config/frontmatter-spec.yaml, reports missing or invalid fields, and optionally auto-adds missing required fields with --fix."
+user_facing: false
 ---
 
 > **Output format:** Follow the [xgh output style guide](../../templates/output-style.md). Start with `## 🐴🤖 xgh frontmatter`. Use markdown tables for structured data. Use ✅ ⚠️ ❌ for status. End with an italicized next step.

--- a/skills/gemini/gemini.md
+++ b/skills/gemini/gemini.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:gemini
 description: "This skill should be used when the user asks to \"dispatch to gemini\", \"run gemini\", \"use gemini for\", \"send to gemini\", \"gemini review\", or wants to delegate implementation or code review tasks to Google's Gemini CLI agent. Supports worktree-isolated parallel dispatch and same-directory sequential dispatch."
+user_facing: false
 ---
 
 > **Context-mode:** This skill primarily runs Bash commands. Use Bash directly for git

--- a/skills/glm/glm.md
+++ b/skills/glm/glm.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:glm
 description: "This skill should be used when the user asks to \"dispatch to glm\", \"run glm\", \"glm exec\", \"glm review\", \"use glm for\", \"send to glm\", or wants to delegate implementation or code review tasks to Z.AI's GLM models via OpenCode CLI. Supports worktree-isolated parallel dispatch and same-directory sequential dispatch."
+user_facing: false
 ---
 
 > **Context-mode:** This skill primarily runs Bash commands. Use Bash directly for git

--- a/skills/index/index.md
+++ b/skills/index/index.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:index
 description: "This skill should be used when the user runs /xgh-index or asks to 'index repo', 'index codebase', 'scan the codebase'. Raw codebase inventory — extracts module list, key files, and naming conventions into lossless-claude memory. Reads stack and surfaces from ~/.xgh/ingest.yaml."
+user_facing: false
 ---
 
 # xgh:index — Codebase Inventory

--- a/skills/init-providers/init-providers.md
+++ b/skills/init-providers/init-providers.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:init-providers
 description: "This skill should be used when the user runs /xgh-init-providers, asks to 'regenerate providers', 'fix empty providers', 'providers directory is empty', or after manually editing ingest.yaml without running /xgh-track. Reads ingest.yaml and generates provider scripts in ~/.xgh/user_providers/ for all projects with github access."
+user_facing: false
 ---
 
 # xgh:init-providers — Generate Provider Scripts from ingest.yaml

--- a/skills/init/init.md
+++ b/skills/init/init.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:init
 description: "This skill should be used when the user runs /xgh-init or says 'set up xgh', 'initialize xgh', 'get started'. First-run onboarding after install — verifies MCP connections, sets up profile, adds first project, runs initial retrieval, and optionally profiles the team and indexes the codebase."
+user_facing: false
 ---
 
 # xgh:init — First-Run Onboarding

--- a/skills/opencode/opencode.md
+++ b/skills/opencode/opencode.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:opencode
 description: "This skill should be used when the user asks to \"dispatch to opencode\", \"run opencode\", \"opencode exec\", \"opencode review\", \"use opencode for\", \"send to opencode\", or wants to delegate implementation or code review tasks to OpenCode CLI agent. Supports worktree-isolated parallel dispatch and same-directory sequential dispatch."
+user_facing: false
 ---
 
 > **Context-mode:** This skill primarily runs Bash commands. Use Bash directly for git

--- a/skills/retrieve/retrieve.md
+++ b/skills/retrieve/retrieve.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:retrieve
 description: "This skill should be used when the user runs /xgh-retrieve or when invoked by the CronCreate scheduler (every 5 minutes). Headless retrieval loop — scans configured Slack channels, follows links 1-hop to Jira/Confluence/GitHub/Figma, stashes raw content to ~/.xgh/inbox/, and detects urgency."
+user_facing: false
 ---
 
 # xgh:retrieve — Retrieval Loop

--- a/skills/schedule/schedule.md
+++ b/skills/schedule/schedule.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:schedule
 description: "This skill should be used when the user runs /xgh-schedule or asks to check, pause, resume, or manage the scheduler, or asks about skill mode preferences. Interactive scheduler control panel — lists, pauses, resumes, and fires xgh CronCreate jobs. Also manages ~/.xgh/prefs.json skill execution mode preferences."
+user_facing: false
 ---
 
 > **Output format:** Start with `## 🐴🤖 xgh schedule`. Use ✅ ⚠️ ❌ for status. Keep output concise.

--- a/skills/seed/seed.md
+++ b/skills/seed/seed.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:seed
 description: "Use when injecting xgh project context into another AI CLI agent before dispatch (Gemini, OpenCode). Writes a project-context brief to .gemini/skills/xgh/ or .opencode/skills/xgh/ so dispatched agents start with project memory pre-loaded."
+user_facing: false
 ---
 
 # xgh:seed — Context Injection for Dispatched Agents

--- a/skills/trigger/trigger.md
+++ b/skills/trigger/trigger.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:trigger
 description: "This skill should be used when the user runs /xgh-trigger or asks to list triggers, test triggers, silence noisy triggers, or view trigger firing history. Manages the xgh trigger engine — list, test, silence, and inspect trigger rules and their firing history."
+user_facing: false
 ---
 
 ---

--- a/skills/validate-project-prefs/validate-project-prefs.md
+++ b/skills/validate-project-prefs/validate-project-prefs.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:validate-project-prefs
 description: "Use when checking that skills read PR workflow values from config/project.yaml instead of hardcoding reviewer logins, repo names, or merge methods; and to audit all 11 preference domains, lib/preferences.sh health, hook ordering, and cross-domain dependencies."
+user_facing: false
 ---
 
 # xgh:validate-project-prefs — Preference Compliance Checker

--- a/skills/watch-prs/watch-prs.md
+++ b/skills/watch-prs/watch-prs.md
@@ -1,6 +1,7 @@
 ---
 name: xgh:watch-prs
 description: "Use /xgh-watch-prs to passively monitor PRs — surfaces review changes, new comments, CI status, and merge-readiness without touching anything. Never merges, never fixes comments, never requests reviews. Pairs with /xgh-ship-prs for active orchestration."
+user_facing: false
 ---
 
 > **Output format:** Start with `## 🐴🤖 xgh watch-prs`. Use markdown tables for state snapshots. Use ✅ ⚠️ ❌ for status. Show change-log between polls as bullet list. Keep per-poll output terse.


### PR DESCRIPTION
## Summary

Reduces session prompt bloat by demoting 20 internal skills that aren't user-facing. These skills remain callable via explicit invocation but are removed from auto-registration.

- Demoted 14 originally flagged internal skills (retrieve, analyze, index, seed, init, init-providers, calibrate, validate-project-prefs, frontmatter, config, schedule, trigger, watch-prs, archive, briefing)
- Absorbed 4 platform dispatchers into dispatch (gemini, glm, opencode, coding-agents)
- Retained 11+ user-facing skills for prompt registration

## Impact

- **Token savings**: ~800 tokens/session (2-3% reduction in context window)
- **User-facing impact**: None — all skills remain accessible via direct invocation
- **Dispatch chain**: Now automatically routes gemini, glm, opencode, coding-agents through dispatch

## Testing

- All skill invocations still work via explicit calls
- User-facing skills remain in prompt
- No behavioral changes to any skill

Closes #194
