### PR TITLE
chore: add auto-label workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+chore:
+  - changed-files:
+    - any-glob-to-any-file: ['.github/**', '*.md', '*.yml', '*.yaml']

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,16 @@
+name: Auto-label PRs
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Auto-label PRs by file path using actions/labeler.

Part of GitHub Pro migration (ipedro/claudinho#237).