### PR TITLE
chore: update repo refs after migration to tokyo-megacorp

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -110,7 +110,7 @@ preferences:
 
   pr:
     provider: github
-    repo: extreme-go-horse/xgh
+    repo: tokyo-megacorp/xgh
     reviewer: copilot-pull-request-reviewer[bot]
     reviewer_comment_author: Copilot
     review_on_push: true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@extreme-go-horse/xgh",
+  "name": "@tokyo-megacorp/xgh",
   "version": "2.3.0",
   "description": "The developer's cockpit — memory, compression, context efficiency, and dev methodology",
   "keywords": [


### PR DESCRIPTION
Updates hardcoded `extreme-go-horse` references after org migration.

- `config/project.yaml`: repo → `tokyo-megacorp/xgh`
- `package.json`: name → `@tokyo-megacorp/xgh`

Remaining cleanup (docs, tests) tracked in #215.