### PR TITLE
feat: skill diet + add security_alerts/dependabot to github provider

### DIFF
--- a/providers/examples/github-cli.yaml
+++ b/providers/examples/github-cli.yaml
@@ -12,7 +12,8 @@ cursor_strategy: iso8601
 #   pull_requests  → gh pr list --search "updated:>CURSOR"
 #   issues         → gh issue list --search "updated:>CURSOR"
 #   actions        → gh run list --created ">CURSOR"
-#   security_alerts→ gh api /repos/O/R/dependabot/alerts
+#   security_alerts→ gh api /repos/O/R/dependabot/alerts (per-alert data, filtered by updated_at)
+#   dependabot     → gh api /repos/O/R/vulnerability-alerts (enabled/disabled status check)
 #   discussions    → gh api graphql (discussions query)
 #   releases       → gh release list
 #   mentions       → gh search issues --mention @me

--- a/skills/deep-retrieve/deep-retrieve.md
+++ b/skills/deep-retrieve/deep-retrieve.md
@@ -1,6 +1,5 @@
 ---
-name: xgh:deep-retrieve
-description: "Use when running /xgh-deep-retrieve or when invoked by the scheduler. Hourly deep scan for new Slack thread replies regardless of parent message age, including threads on previously-clean messages. Complements xgh:retrieve."
+description: "Internal pipeline skill — invoked by the scheduler hourly. Deep scan for new Slack thread replies regardless of parent message age, including threads on previously-clean messages. Complements xgh:retrieve. Not user-facing: use /xgh-deep-retrieve command instead."
 ---
 
 # xgh:deep-retrieve — Deep Thread Scan

--- a/skills/init-providers/init-providers.md
+++ b/skills/init-providers/init-providers.md
@@ -1,6 +1,5 @@
 ---
-name: xgh:init-providers
-description: "This skill should be used when the user runs /xgh-init-providers, asks to 'regenerate providers', 'fix empty providers', 'providers directory is empty', or after manually editing ingest.yaml without running /xgh-track. Reads ingest.yaml and generates provider scripts in ~/.xgh/user_providers/ for all projects with github access."
+description: "Internal repair-path skill — invoked when the user runs /xgh-init-providers, asks to 'regenerate providers', 'fix empty providers', 'providers directory is empty', or after manually editing ingest.yaml without running /xgh-track. Reads ingest.yaml and generates provider scripts in ~/.xgh/user_providers/ for all projects with github access. Not user-facing: use /xgh-init-providers command instead."
 ---
 
 # xgh:init-providers — Generate Provider Scripts from ingest.yaml
@@ -28,7 +27,7 @@ github_repos = {}  # project_name -> {repos: [], sources: []}
 for project_name, project in projects.items():
     if project.get('providers', {}).get('github'):
         repos = project.get('github', [])
-        sources = project.get('github_sources', ['issues', 'pull_requests', 'releases'])
+        sources = project.get('github_sources', ['issues', 'pull_requests', 'releases', 'security_alerts', 'dependabot'])
         if repos:
             github_repos[project_name] = {'repos': repos, 'sources': sources}
 ```
@@ -60,12 +59,12 @@ command -v gh && gh auth status
 service: github
 mode: cli
 cursor_strategy: timestamp
-description: Fetches GitHub issues, pull requests, and releases for all tracked repos using gh CLI
+description: Fetches GitHub issues, pull requests, releases, security alerts, and Dependabot alerts for all tracked repos using gh CLI
 
 sources:
   - project: <project_name>
     repo: <github_repo>
-    types: <github_sources filtered to [issues, pull_requests, releases]>
+    types: <github_sources filtered to [issues, pull_requests, releases, security_alerts, dependabot]>
   # ... one entry per project with github repos
 ```
 
@@ -74,16 +73,20 @@ sources:
 The script must:
 1. Read `CURSOR_FILE` env var for incremental pagination (ISO timestamp)
 2. Default to 24h ago if no cursor exists
-3. For each repo in the provider, run `gh issue list`, `gh pr list`, `gh release list`
-   with `--json` and filter by `updatedAt > SINCE`
+3. For each repo in the provider, based on the configured `types`, run:
+   - `issues` → `gh issue list --json` filtered by `updatedAt > SINCE`
+   - `pull_requests` → `gh pr list --json` filtered by `updatedAt > SINCE`
+   - `releases` → `gh release list --json` filtered by `createdAt > SINCE`
+   - `security_alerts` → `gh api /repos/$OWNER/$REPO/dependabot/alerts --jq '.[] | select(.updated_at > $SINCE)'`
+   - `dependabot` → `gh api /repos/$OWNER/$REPO/vulnerability-alerts` (returns enabled/disabled status; for per-alert data use `security_alerts`)
 4. Write each result to `$INBOX_DIR/<timestamp>_github_<repo_slug>_<type><number>.md`
    with frontmatter:
    ```
    ---
    type: inbox_item
-   source_type: github_<issue|pr|release>
+   source_type: github_<issue|pr|release|security_alert|dependabot>
    source_repo: <owner/repo>
-   source_ts: <updatedAt>
+   source_ts: <updatedAt or updated_at>
    project: <project_name>
    urgency_score: 50
    processed: false

--- a/skills/retrieve/retrieve.md
+++ b/skills/retrieve/retrieve.md
@@ -1,6 +1,5 @@
 ---
-name: xgh:retrieve
-description: "This skill should be used when the user runs /xgh-retrieve or when invoked by the CronCreate scheduler (every 5 minutes). Headless retrieval loop — scans configured Slack channels, follows links 1-hop to Jira/Confluence/GitHub/Figma, stashes raw content to ~/.xgh/inbox/, and detects urgency."
+description: "Internal pipeline skill — invoked by CronCreate scheduler (every 5 minutes). Headless retrieval loop — scans configured Slack channels, follows links 1-hop to Jira/Confluence/GitHub/Figma, stashes raw content to ~/.xgh/inbox/, and detects urgency. Not user-facing: use /xgh-retrieve command instead."
 ---
 
 # xgh:retrieve — Retrieval Loop

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -88,7 +88,7 @@ assert_contains "config/project.yaml" "xgh:codex"
 # --- preferences.pr section ---
 assert_contains "config/project.yaml" "pr:"
 assert_contains "config/project.yaml" "provider: github"
-assert_contains "config/project.yaml" "repo: extreme-go-horse/xgh"
+assert_contains "config/project.yaml" "repo: tokyo-megacorp/xgh"
 assert_contains "config/project.yaml" "copilot-pull-request-reviewer\[bot\]"
 assert_contains "config/project.yaml" "reviewer_comment_author: Copilot"
 assert_contains "config/project.yaml" "merge_method: squash"


### PR DESCRIPTION
## Summary
- Demote `retrieve`, `deep-retrieve`, `init-providers` from user-visible skill registration by removing `name:` frontmatter — CronCreate invokes these by path, not by name, so scheduling is unaffected (#194)
- Add `security_alerts` and `dependabot` as `github_sources` options in init-providers skill and fetch.sh template (#192)

## Test plan
- [x] test-config.sh: 126/126 passed
- [x] test-shellcheck.sh: 85/85 passed

Closes #192, #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)